### PR TITLE
feat(order-router): scaffold ccxt-based smart order router service

### DIFF
--- a/.github/workflows/order-router.yml
+++ b/.github/workflows/order-router.yml
@@ -1,0 +1,111 @@
+name: Order Router
+
+# Scoped to the order-router service only. It is a standalone Node/TypeScript app that depends on
+# the published ccxt package — it is not part of the transpile pipeline, so it deliberately does
+# not run on changes elsewhere in the repo, and nothing here touches ts/src or generated output.
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, master ]
+    paths:
+      - 'order-router/**'
+      - '.github/workflows/order-router.yml'
+  pull_request:
+    paths:
+      - 'order-router/**'
+      - '.github/workflows/order-router.yml'
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: order-router
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: order-router/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check and build
+        run: npm run build
+
+      - name: Unit tests
+        # Offline by design: no live exchange connections, no network. Anything needing a real
+        # exchange lives in benchmark/ and is run manually (see order-router/README.md).
+        run: npm test
+
+      - name: Verify the service boots and serves authenticated requests
+        # Smoke test that catches wiring regressions unit tests can't: real process, real HTTP
+        # listener, real auth middleware. Uses a single exchange to keep it quick, and tolerates
+        # exchange unreachability from the runner (asserted endpoints do not require live data).
+        env:
+          ORDER_ROUTER_API_KEY: ci-smoke-key
+          ORDER_ROUTER_EXCHANGES: kraken
+          ORDER_ROUTER_SYMBOLS: BTC/USDT
+          LOG_LEVEL: warn
+        run: |
+          node dist/index.js > /tmp/router.log 2>&1 &
+          ROUTER_PID=$!
+          trap 'kill $ROUTER_PID 2>/dev/null || true' EXIT
+
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/health > /dev/null; then break; fi
+            if ! kill -0 $ROUTER_PID 2>/dev/null; then
+              echo "::error::router process exited during startup"; cat /tmp/router.log; exit 1
+            fi
+            sleep 1
+          done
+
+          echo "--- /health must be reachable without credentials (probe path) ---"
+          curl -sf http://localhost:8080/health | grep -q '"status":"ok"'
+
+          echo "--- protected route must reject an unauthenticated request with 401 ---"
+          code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/symbols)
+          if [ "$code" != "401" ]; then echo "::error::expected 401, got $code"; exit 1; fi
+
+          echo "--- protected route must accept a valid key ---"
+          code=$(curl -s -o /dev/null -w '%{http_code}' -H 'x-api-key: ci-smoke-key' http://localhost:8080/symbols)
+          if [ "$code" != "200" ]; then echo "::error::expected 200, got $code"; cat /tmp/router.log; exit 1; fi
+
+          echo "--- a wrong key must still be rejected ---"
+          code=$(curl -s -o /dev/null -w '%{http_code}' -H 'x-api-key: wrong-key' http://localhost:8080/symbols)
+          if [ "$code" != "401" ]; then echo "::error::expected 401, got $code"; exit 1; fi
+
+          echo "smoke test passed"
+
+      - name: Verify the MCP server boots and enforces auth
+        env:
+          ORDER_ROUTER_API_KEY: ci-smoke-key
+          ORDER_ROUTER_MCP_PORT: 8081
+          LOG_LEVEL: warn
+        run: |
+          node dist/mcp/server.js > /tmp/mcp.log 2>&1 &
+          MCP_PID=$!
+          trap 'kill $MCP_PID 2>/dev/null || true' EXIT
+
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8081/health > /dev/null; then break; fi
+            if ! kill -0 $MCP_PID 2>/dev/null; then
+              echo "::error::MCP process exited during startup"; cat /tmp/mcp.log; exit 1
+            fi
+            sleep 1
+          done
+
+          echo "--- /mcp must reject an unauthenticated JSON-RPC call ---"
+          code=$(curl -s -o /dev/null -w '%{http_code}' -X POST http://localhost:8081/mcp \
+            -H 'content-type: application/json' \
+            -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}')
+          if [ "$code" != "401" ]; then echo "::error::expected 401, got $code"; cat /tmp/mcp.log; exit 1; fi
+
+          echo "MCP smoke test passed"

--- a/order-router/.gitignore
+++ b/order-router/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/order-router/Dockerfile
+++ b/order-router/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:22-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --no-audit --no-fund
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:22-slim
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --no-audit --no-fund
+COPY --from=build /app/dist ./dist
+EXPOSE 8080
+CMD ["node", "dist/index.js"]

--- a/order-router/README.md
+++ b/order-router/README.md
@@ -181,7 +181,11 @@ either `X-API-Key: <key>` or `Authorization: Bearer <key>`.
 - Responses carry `x-ratelimit-*` and `retry-after`.
 
 The MCP server authenticates its own callers with the same key and forwards it upstream; without
-that it would be an unauthenticated bypass around the router's auth.
+that it would be an unauthenticated bypass around the router's auth. It runs in a separate process
+on a separate port, so the Fastify limiter does not cover it — it therefore has its own limiter
+(`src/api/rateLimiter.ts`, a small fixed-window implementation mirroring the same
+bucket-by-key-only-when-valid semantics). Omitting it left a second, equivalent brute-force door
+open on :8081 after the first was closed on :8080.
 
 ## MCP server (`src/mcp/`)
 

--- a/order-router/README.md
+++ b/order-router/README.md
@@ -161,6 +161,15 @@ either `X-API-Key: <key>` or `Authorization: Bearer <key>`.
   logs a loud warning at startup. That default grants no security; it exists so local dev works
   and so an unconfigured deployment is obviously wrong rather than subtly wrong.
 
+**WebSocket stream limits.** Each `/stream/best` connection holds a cache listener removed only on
+socket close — which the client controls — and costs a recomputation on every book update for its
+symbol. Rate limiting bounds how fast connections open, not how many stay open, so it does not
+help here. Two mechanisms bound it: a per-key concurrency cap (`ORDER_ROUTER_WS_MAX_CONNECTIONS_PER_KEY`,
+default 50, refused with a `1013` close), and a ping/pong heartbeat that terminates sockets which
+stop responding without ever sending a close frame (half-open TCP, suspended clients) and would
+otherwise hold their listener and cap slot forever. Slot release is idempotent — releasing twice
+would corrupt the count and eventually lock a legitimate client out of its own budget.
+
 **Rate limiting** (`@fastify/rate-limit`). Default 600 requests / 60s.
 
 - Runs **before** auth, so a flood of invalid keys burns rate-limit budget instead of probing the
@@ -239,6 +248,8 @@ against a running router with live exchange data) during development — not jus
 | `ORDER_ROUTER_API_KEY` | `dev-local-key-change-me` | **Set this in any real deployment.** The default grants no security and logs a warning. |
 | `ORDER_ROUTER_RATE_LIMIT_MAX` | `600` | Requests per window, per API key. |
 | `ORDER_ROUTER_RATE_LIMIT_WINDOW_MS` | `60000` | Rate limit window. |
+| `ORDER_ROUTER_WS_MAX_CONNECTIONS_PER_KEY` | `50` | Max concurrent `/stream/best` sockets per API key. |
+| `ORDER_ROUTER_WS_IDLE_TIMEOUT_MS` | `120000` | Heartbeat interval; a socket that misses two beats is terminated. |
 | `LOG_LEVEL` | `info` | |
 
 ## Run
@@ -315,11 +326,11 @@ Connects to each candidate exchange, holds for a set duration, reports message c
 Highest-volume: kucoin (14,809 msgs), poloniex (7,500), gate (1,791), htx (676), bitget (563),
 coinbase (493). Median time-to-first-message ~1.8s.
 
-The 6 failures are all explainable, none are router bugs:
+The 6 failures are all explainable, none are router bugs (`mexc` has since been fixed by adding
+`protobufjs`, verified live — 104 bids / 108 asks — so the reachable count is now 29):
 
 | Exchange | Reason |
 |---|---|
-| `mexc` | needs the optional `protobufjs` peer dep to decode WS frames — installable, not yet done |
 | `cex`, `luno` | require API credentials even for public WS |
 | `okx`, `binanceus`, `independentreserve` | no data within 20s — the same egress geo-restriction that blocks Binance/Bybit from this sandbox |
 
@@ -395,6 +406,7 @@ Not ready to expose publicly. Honest status of the blockers:
 | No soak testing | **Open** — longest continuous run is minutes, not hours/days |
 | No metrics/alerting | **Open** — only `/exchanges/status` |
 | No HA/failover | **Open** — a dead process is an outage |
+| Unbounded WS connections (finding #4b) | **Closed** — per-key concurrency cap + heartbeat reaper, regression-tested |
 
 ## Known gaps / next steps
 
@@ -402,7 +414,6 @@ Not ready to expose publicly. Honest status of the blockers:
   full discovery scale (76 exchanges) rather than the 5-exchange subset reachable from this sandbox.
 - Replace shared-key auth with something real (per-client keys + rotation + revocation) before any
   public exposure, and put TLS termination in front.
-- Install `protobufjs` to unblock `mexc` WS decoding (one dependency; not yet done).
 - Soak test: hours-to-days continuous run with `process.memoryUsage()` tracked, to find leaks and
   slow connection drift that a 75-second test can't.
 - `ORDER_ROUTER_MAX_SYMBOLS_PER_EXCHANGE` needs real per-exchange tuning under production load —

--- a/order-router/README.md
+++ b/order-router/README.md
@@ -296,6 +296,38 @@ lifecycle (reconnect/backoff/jitter against a real socket), discovery's `loadMar
 calls, and sharding's actual `child_process` IPC (verified live, not by an automated test, since
 that requires spawning real subprocesses with real network access).
 
+## Metrics
+
+`GET /metrics` serves Prometheus text format. **Authenticated like every other non-`/health` route**
+— it exposes the venue list, traffic volume and internal health, which is exactly the
+reconnaissance an attacker would want, so scrapers must send the API key.
+
+Values are **derived from cache state at scrape time** rather than incremented alongside it. The
+cache already owns the authoritative counters, and mirroring them into separate Prometheus counters
+would create two sources of truth that can drift, where a missed increment is invisible. Reading
+through a `collect()` callback makes disagreement with `/exchanges/status` structurally impossible.
+The trade-off is that cumulative series are Gauges whose values happen to be monotonic rather than
+Counters — `rate()`/`increase()` still work, and a restart resets to 0 exactly as a Counter would.
+
+| Metric | Why it's here |
+|---|---|
+| `order_router_exchange_last_update_age_seconds` | **The most important alert.** An exchange can hold an open socket while its subscription is silently dead — `connected` stays 1, nothing errors, and the router keeps ranking on rotting data. Connection state alone will not catch this. An exchange that has *never* updated reports process uptime rather than 0, so a connector that never produced a message is loud instead of indistinguishable from one that just updated. |
+| `order_router_stale_books` | How much of the cache is currently too old to rank with — i.e. actively degrading answer quality. |
+| `order_router_exchange_reconnects_total` | Reconnect storms were a real failure in live testing (1,000–2,500 in 15s); this is the signal that they have returned. |
+| `order_router_exchange_connected` / `_updates_total` | Per-exchange liveness and throughput; a flat update count on a connected exchange is a dead subscription. |
+| `order_router_cached_books` / `_cached_symbols` | Coverage — a drop means discovery or subscriptions regressed. |
+| `order_router_ws_stream_connections` | Open `/stream/best` sockets, to watch pressure against the per-key cap. |
+| `order_router_http_request_duration_seconds` | Latency histogram; its `_count` doubles as the request counter. Buckets are tuned sub-10ms because reads are in-memory map lookups. |
+| `order_router_nodejs_*` | Default process metrics. **Event loop lag** matters most — it is the first thing to degrade when WS message volume outruns the single thread. |
+
+Histogram labels use the **route template** (`/orderbook/:exchange/:symbol`), never the raw URL.
+Labelling by concrete symbol would mint one series per symbol across a ~10k routable universe and
+blow up Prometheus cardinality.
+
+Suggested alerts: `order_router_exchange_last_update_age_seconds > 60` (dead subscription),
+`order_router_stale_books / order_router_cached_books > 0.2` (widespread staleness),
+`rate(order_router_exchange_reconnects_total[5m])` above a per-exchange baseline (reconnect storm).
+
 ## Continuous integration
 
 `.github/workflows/order-router.yml` runs on any change under `order-router/` (and nothing else —
@@ -404,7 +436,7 @@ Not ready to expose publicly. Honest status of the blockers:
 | Binance/Bybit/OKX never live-tested | **Open** — geo-blocked from every environment available here |
 | No TLS, runs plain HTTP | **Open** — assumes a terminating proxy in front; not documented or provisioned |
 | No soak testing | **Open** — longest continuous run is minutes, not hours/days |
-| No metrics/alerting | **Open** — only `/exchanges/status` |
+| No metrics/alerting | **Closed for instrumentation** — Prometheus `/metrics` with staleness, reconnect, throughput and event-loop-lag signals. **Still open:** nothing scrapes it and no alerts are wired up; the suggested rules above are untested. |
 | No HA/failover | **Open** — a dead process is an outage |
 | Unbounded WS connections (finding #4b) | **Closed** — per-key concurrency cap + heartbeat reaper, regression-tested |
 

--- a/order-router/README.md
+++ b/order-router/README.md
@@ -1,0 +1,102 @@
+# order-router
+
+Smart order router built on [ccxt](https://github.com/ccxt/ccxt). Maintains live L2 order books
+for configured exchanges/symbols over WebSocket, caches them in-process, and serves best-execution
+price lookups that account for order size (book-walking, not just top-of-book) and taker fees.
+
+This is a standalone service that *depends on* ccxt as a library — it does not modify `ts/src/**`
+and is not part of the ccxt build/transpile pipeline.
+
+## Architecture
+
+```
+Fastify API (reads in-process cache only, no network hop on the read path)
+        │
+OrderBookCache (Map<exchange, Map<symbol, L2 book>>, in-memory)
+        │
+ExchangeConnector × N (one per exchange, isolated failure domain, ccxt.pro watchOrderBook loop)
+```
+
+- **In-memory is the hot path.** A single instance's API reads never touch Redis/network — see
+  `src/cache/orderBookCache.ts`. Redis is not wired up in v1 (single-instance scope); it becomes
+  relevant only when running multiple API replicas that need to share connector state, at which
+  point a connector-writes-to-Redis-pubsub / API-replica-subscribes pattern is the natural extension.
+- **Book-walking, not best-bid/ask.** `/price/best/:symbol` requires an `amount` and walks each
+  exchange's cached book to that depth, computing the volume-weighted average price plus taker fee —
+  because for any non-trivial order size, the venue with the best top-of-book price is not
+  necessarily the venue with the best price for your actual size.
+- **Per-exchange isolation.** Each `ExchangeConnector` owns its own WS connection(s) and
+  reconnects with exponential backoff independently; one exchange misbehaving (rate limit,
+  disconnect storm) never affects others or the API.
+
+## Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/health` | liveness |
+| GET | `/exchanges/status` | per-exchange WS health: connected, last update age, update/reconnect counts |
+| GET | `/symbols` | symbols currently cached |
+| GET | `/orderbook/:exchange/:symbol` | cached L2 book snapshot (symbol URL-encoded, e.g. `BTC%2FUSDT`) |
+| GET | `/price/best/:symbol?side=buy\|sell&amount=<qty>` | book-walked, fee-adjusted best execution price across exchanges |
+| WS | `/stream/best/:symbol?side=&amount=` | pushes the same result every 250ms |
+
+## Config (env vars)
+
+| Var | Default |
+|---|---|
+| `PORT` | `8080` |
+| `ORDER_ROUTER_EXCHANGES` | `kraken,coinbase,kucoin,bitget,gate` |
+| `ORDER_ROUTER_SYMBOLS` | `BTC/USDT,ETH/USDT` |
+| `ORDER_ROUTER_STALE_BOOK_MS` | `5000` — quotes from books older than this are excluded from ranking |
+| `LOG_LEVEL` | `info` |
+
+## Run
+
+```bash
+npm install
+npm run dev        # tsx watch
+# or
+npm run build && npm start
+# or
+docker compose up --build
+```
+
+## Benchmark (`benchmark/ws-latency.mjs`)
+
+`npm run bench:ws` measures WS update rate, message latency, and cached book depth per exchange.
+
+### Results from this dev sandbox — read the caveats before trusting these numbers
+
+1. **Binance, Bybit, OKX were unreachable from this sandbox.** Binance/Bybit REST calls returned
+   `451`/`403` geo-compliance blocks; OKX's WS connection timed out. This is specific to this
+   container's egress IP, not a ccxt limitation. These three are typically the deepest/fastest
+   venues in production and **must be re-benchmarked from the actual deployment host** before
+   finalizing the exchange list.
+2. **Absolute latency figures are unreliable.** Several exchanges reported negative
+   exchange-timestamp-to-receipt latency, meaning this container's clock is not NTP-synced against
+   exchange time sources. Re-run with `chrony`/NTP synced on the benchmark host for trustworthy
+   absolute numbers. Update frequency and book depth (below) don't depend on clock sync and are valid.
+
+| Exchange | Updates / 30s | Book depth (levels) |
+|---|---|---|
+| KuCoin | 14,432 (~480/s) | 60–245 |
+| Kraken | 3,219 (~107/s) | 10 (fixed) |
+| Gate | 944 (~31/s) | 50 (fixed) |
+| Coinbase | 483 (~16/s) | 1,070–1,103 (near-full L2) |
+| Bitget | 281 (~9/s) | 500 (fixed) |
+
+Takeaway: Kraken/Gate cap streamed depth at 10/50 levels, which limits how large an order can be
+routed confidently before you'd need a periodic REST depth-snapshot fallback for those venues.
+Coinbase streams close to the full book.
+
+## Known gaps / next steps
+
+- Re-run the benchmark from unrestricted, NTP-synced infra, including Binance/Bybit/OKX.
+- Order *execution* routing (actually placing orders) is out of scope for this milestone — see
+  the repo's live-trading safety rules (25 USD/trade cap, no live `withdraw()` testing) before
+  building that; it needs API keys, risk limits, and per-exchange cleanup logic.
+- No Redis/multi-instance story yet — single instance only, by design (see Architecture above).
+- No Prometheus `/metrics` endpoint yet — `/exchanges/status` covers health for now.
+- Depth-limited exchanges (Kraken, Gate, others with capped WS depth) should fall back to REST
+  `fetchOrderBook` snapshots when a requested `amount` exceeds cached depth, rather than silently
+  reporting `fullyFillable: false`.

--- a/order-router/README.md
+++ b/order-router/README.md
@@ -152,19 +152,30 @@ either `X-API-Key: <key>` or `Authorization: Bearer <key>`.
 - Keys are compared through SHA-256 digests + `timingSafeEqual`, not `===`. Digesting first makes
   both sides a fixed 32 bytes, so the comparison leaks neither key length nor common prefix
   through timing, and can't throw on a length mismatch.
-- The auth hook runs at `onRequest`, i.e. **before routing**, so unknown paths return `401` rather
-  than `404` — no oracle for enumerating which routes exist. Missing and wrong keys produce
-  byte-identical responses for the same reason.
+- The auth hook runs at **`preValidation`**, not `onRequest` — deliberately, and this ordering is
+  load-bearing (see Rate limiting below). Unknown paths still return `401` rather than `404` for
+  unauthenticated callers, via a custom not-found handler that re-checks the key, so there's no
+  oracle for enumerating which routes exist; authenticated callers still get a truthful `404`.
+  Missing and wrong keys produce byte-identical responses for the same reason.
 - Unset `ORDER_ROUTER_API_KEY` falls back to the well-known literal `dev-local-key-change-me` and
   logs a loud warning at startup. That default grants no security; it exists so local dev works
   and so an unconfigured deployment is obviously wrong rather than subtly wrong.
 
 **Rate limiting** (`@fastify/rate-limit`). Default 600 requests / 60s.
 
-- Registered *before* the auth hook, so a flood of invalid keys burns rate-limit budget instead of
-  reaching the key comparison unbounded.
-- Bucketed **per API key** (falling back to IP only where no key is present), so one client can't
-  exhaust another's budget and clients behind a shared NAT aren't collectively throttled.
+- Runs **before** auth, so a flood of invalid keys burns rate-limit budget instead of probing the
+  key comparison unbounded. This ordering is *not* automatic and was originally wrong: because
+  `@fastify/rate-limit` attaches its check as a per-route hook, and route-level `onRequest` hooks
+  run after all instance-level ones, an instance-level auth hook at `onRequest` always preceded
+  the limiter regardless of registration order — so every `401` short-circuited before being
+  counted, and key brute-force was completely unthrottled while authenticated traffic looked
+  correctly limited. Auth therefore runs at `preValidation`, which is after the whole `onRequest`
+  chain. Regression-tested, since testing only the authenticated path cannot catch this.
+- Bucketed **per API key only once the key is valid**; wrong or absent keys bucket by IP. Bucketing
+  unconditionally on the caller-supplied header is a trap — an attacker rotates the header per
+  request, mints a fresh bucket each time, and brute-forces without ever being throttled (it is
+  also an unbounded-memory vector). Valid clients still get per-key fairness, so one can't exhaust
+  another's budget and NAT'd clients aren't collectively throttled.
 - `/health` is exempt — a throttled liveness probe reads as an outage to an orchestrator and would
   trigger restarts under exactly the load where that's worst.
 - Responses carry `x-ratelimit-*` and `retry-after`.

--- a/order-router/README.md
+++ b/order-router/README.md
@@ -136,6 +136,40 @@ same "write path is async, read path is always local" shape, is a natural extens
 | GET | `/price/best/:symbol?side=buy\|sell&amount=<qty>` | book-walked, fee-adjusted best execution price across exchanges |
 | WS | `/stream/best/:symbol?side=&amount=` | pushes on book change (event-driven, not polled) |
 
+## MCP server (`src/mcp/`)
+
+A separate process (`npm run mcp` / `npm run mcp:dev`) exposing the same public endpoints as MCP
+tools over the [Streamable HTTP transport](https://modelcontextprotocol.io/), so an MCP client
+(Claude Code, Claude Desktop, etc.) can query the router directly. It's a thin proxy — `src/mcp/tools.ts`
+just calls the router's own REST API (`ORDER_ROUTER_API_URL`, default `http://localhost:8080`) —
+not a second implementation of the routing logic, so its behavior is exactly the REST API's
+behavior. Runs on its own port (`ORDER_ROUTER_MCP_PORT`, default `8081`) and its own process,
+decoupled from the router's hot path — an MCP client's traffic never touches the router's
+in-memory cache or event loop directly.
+
+| Tool | Maps to |
+|---|---|
+| `get_health` | `GET /health` |
+| `get_exchanges_status` | `GET /exchanges/status` |
+| `list_symbols` | `GET /symbols` |
+| `get_order_book` (`exchange`, `symbol`) | `GET /orderbook/:exchange/:symbol` |
+| `get_best_price` (`symbol`, `side`, `amount`) | `GET /price/best/:symbol?side=&amount=` |
+
+Run both together:
+
+```bash
+npm run build
+node dist/index.js &                          # router on :8080
+ORDER_ROUTER_API_URL=http://localhost:8080 node dist/mcp/server.js &  # MCP on :8081
+```
+
+or `docker compose up --build`, which starts both as separate containers on the same network
+(the MCP container points `ORDER_ROUTER_API_URL` at the router container's Docker DNS name).
+
+To connect from an MCP client: add an HTTP MCP server pointed at `http://<host>:8081/mcp`. Verified
+live end-to-end (real `Client`/`StreamableHTTPClientTransport` from `@modelcontextprotocol/sdk`
+against a running router with live exchange data) during development — not just the unit tests.
+
 ## Config (env vars)
 
 | Var | Default | Notes |
@@ -168,6 +202,34 @@ docker compose up --build
 
 Sharding (`ORDER_ROUTER_SHARD_COUNT>1`) forks compiled `dist/sharding/shardWorker.js` — build first
 (`npm run build`) before using it; `npm run dev` (tsx) does not support sharding today.
+
+## Testing
+
+```bash
+npm test    # node:test via tsx, no network required
+```
+
+49 tests, all offline — no live exchange connections, no mocked `fetch` (HTTP-touching code is
+tested against real local fixtures: `node:http` servers for the MCP proxy layer, Fastify's
+`inject()` for the REST API, `node:child_process`-free logic-only tests for sharding). Coverage:
+
+| Area | File | What's covered |
+|---|---|---|
+| Book-walking / fee ranking | `src/routing/bestPrice.test.ts` | VWAP across levels, fee-adjusted ranking beats raw-price ranking, partial fills, buy vs. sell side, stale-book exclusion |
+| In-memory cache | `src/cache/orderBookCache.test.ts` | get/set, per-symbol event scoping, health lifecycle, unknown-exchange no-ops |
+| Fee registry | `src/cache/feeRegistry.test.ts` | fallback, per-(exchange,symbol) scoping, event emission (used for shard IPC) |
+| Symbol universe filtering | `src/discovery/symbolUniverse.test.ts` | the ≥N-exchange routability rule, threshold edge cases, empty input |
+| Subscription chunking | `src/connectors/exchangeConnector.test.ts` | `chunkSymbols`/`normalizeLevels` pure helpers extracted from the connector |
+| Shard load-balancing | `src/sharding/orchestrator.test.ts` | every exchange assigned exactly once, greedy balance, shard-count edge cases |
+| REST API | `src/api/server.test.ts` | all 5 HTTP routes via Fastify `inject()` against a real in-memory cache |
+| MCP proxy layer | `src/mcp/tools.test.ts` | URL construction, error propagation, against a real local HTTP fixture |
+| MCP protocol | `src/mcp/server.test.ts` | real `Client`/`McpServer` over `InMemoryTransport` — tool listing, tool calls, Zod input validation surfacing as MCP tool errors |
+
+Not covered by unit tests (needs live exchanges, covered by manual verification during
+development instead — see git history / PR description): `ExchangeConnector`'s actual WS
+lifecycle (reconnect/backoff/jitter against a real socket), discovery's `loadMarkets()` network
+calls, and sharding's actual `child_process` IPC (verified live, not by an automated test, since
+that requires spawning real subprocesses with real network access).
 
 ## Benchmark (`benchmark/ws-latency.mjs`)
 

--- a/order-router/README.md
+++ b/order-router/README.md
@@ -1,8 +1,10 @@
 # order-router
 
-Smart order router built on [ccxt](https://github.com/ccxt/ccxt). Maintains live L2 order books
-for configured exchanges/symbols over WebSocket, caches them in-process, and serves best-execution
-price lookups that account for order size (book-walking, not just top-of-book) and taker fees.
+Smart order router built on [ccxt](https://github.com/ccxt/ccxt). Discovers every ccxt.pro
+exchange, loads their markets, and subscribes to the *routable* symbol universe — every symbol
+tradable on 2+ exchanges — over WebSocket. Caches live L2 order books in-process and serves
+best-execution price lookups that account for order size (book-walking, not just top-of-book) and
+taker fees.
 
 This is a standalone service that *depends on* ccxt as a library — it does not modify `ts/src/**`
 and is not part of the ccxt build/transpile pipeline.
@@ -12,27 +14,77 @@ and is not part of the ccxt build/transpile pipeline.
 ```
 Fastify API (reads in-process cache only, no network hop on the read path)
         │
-OrderBookCache (Map<exchange, Map<symbol, L2 book>>, in-memory)
+OrderBookCache + FeeRegistry (in-memory, EventEmitter-based)
         │
-ExchangeConnector × N (one per exchange, isolated failure domain, ccxt.pro watchOrderBook loop)
+        ├── single-process mode (ORDER_ROUTER_SHARD_COUNT=1): ExchangeConnector × N in this process
+        │
+        └── sharded mode (ORDER_ROUTER_SHARD_COUNT>1): child_process per shard, each running its
+            own ExchangeConnector × N, relaying book/health/fee writes to the parent over IPC
 ```
 
-- **In-memory is the hot path.** A single instance's API reads never touch Redis/network — see
-  `src/cache/orderBookCache.ts`. Redis is not wired up in v1 (single-instance scope); it becomes
-  relevant only when running multiple API replicas that need to share connector state, at which
-  point a connector-writes-to-Redis-pubsub / API-replica-subscribes pattern is the natural extension.
+- **In-memory is the hot path.** The API's read path is always a plain in-process `Map` lookup —
+  see `src/cache/orderBookCache.ts`. In sharded mode, a shard's connector writes cross a process
+  boundary via IPC (same-host pipe, no external DB, no request-time cost — see "Why single-process
+  Node..." below), but the API's *reads* never do, whether sharded or not.
 - **Book-walking, not best-bid/ask.** `/price/best/:symbol` requires an `amount` and walks each
   exchange's cached book to that depth, computing the volume-weighted average price plus taker fee —
   because for any non-trivial order size, the venue with the best top-of-book price is not
   necessarily the venue with the best price for your actual size.
 - **Per-exchange isolation.** Each `ExchangeConnector` owns its own WS connection(s) and
-  reconnects with exponential backoff independently; one exchange misbehaving (rate limit,
-  disconnect storm) never affects others or the API.
+  reconnects with exponential backoff (plus jitter — see below) independently; one exchange
+  misbehaving never affects others or the API.
 - **Push-on-change, not polling.** `OrderBookCache` extends `EventEmitter` and emits
   `update:<symbol>` whenever a book changes; `/stream/best/:symbol` subscribes to that instead of
   polling on a fixed interval, coalescing bursts into at most one computed result per event-loop
-  tick via `setImmediate`. A poll-based design costs CPU proportional to `poll_rate x client_count`
-  regardless of whether anything changed — doesn't hold up once client/message volume is large.
+  tick via `setImmediate`.
+
+### Discovery: only subscribe where routing has value
+
+A symbol listed on exactly one exchange has nothing to route between — subscribing to it costs a
+WS subscription, memory, and CPU for zero comparative value. Measured directly across just 5
+exchanges (Kraken, Coinbase, KuCoin, Bitget, Gate): **9,412 unique unified symbols, of which only
+2,102 (22%) trade on 2+ of those exchanges.** The other 78% are single-exchange noise for a router.
+
+`ORDER_ROUTER_DISCOVER_ALL=true` turns this on: `src/discovery/exchangeDiscovery.ts` lists every
+ccxt.pro exchange with `has.watchOrderBook` (76 out of 80 exchange classes, checked locally with no
+network calls), `src/discovery/symbolUniverse.ts` loads markets for all of them (bounded
+concurrency, tolerant of individual failures — one geo-blocked exchange doesn't abort discovery),
+and builds a `symbol -> Set<exchangeId>` index. Only symbols meeting `ORDER_ROUTER_MIN_EXCHANGES_PER_SYMBOL`
+(default 2) become subscriptions.
+
+### Subscription mechanics — what actually broke in testing, and the fixes
+
+Naively spawning one independent `watchOrderBook(symbol)` loop per routable symbol (the original
+v1 design) does not survive contact with real exchanges once the symbol count gets large. Live
+testing against Kraken/Coinbase/KuCoin/Bitget/Gate with their full routable symbol sets (up to
+~1,700+ symbols on one exchange) surfaced three distinct failures, each with a specific fix:
+
+1. **Reconnect storms.** With N independent per-symbol loops, any shared-connection hiccup fails
+   all N simultaneously; with identical backoff timers they all retry in lockstep, repeatedly
+   re-triggering exchange-side rate limits. Observed: 1,000–2,500+ reconnects within 15 seconds on
+   KuCoin/Bitget. Fix: **prefer `watchOrderBookForSymbols(symbols)`** (one batched subscription)
+   over per-symbol loops wherever the exchange supports it (24 of the exchanges checked do,
+   including all of Kraken/Coinbase/KuCoin/Bitget in this test set — only Gate in this set falls
+   back to per-symbol), and add **full jitter to backoff** so loops that failed together don't
+   retry together.
+2. **Per-message/per-connection subscription caps.** Even batched, sending hundreds of symbols in
+   one `watchOrderBookForSymbols` call trips server-side limits — observed directly: Bitget
+   (`"subscribe over limit, max:1000"`), KuCoin (rejects an overlong comma-joined topic string).
+   Fix: **chunk into `ORDER_ROUTER_MAX_SYMBOLS_PER_SUBSCRIPTION`-sized groups** (default 50), each
+   its own independent watch loop, with staggered startup (`LOOP_START_STAGGER_MS`) so chunks
+   don't all subscribe in the same instant either.
+3. **Session-wide caps that chunking alone can't fix.** Coinbase rejected the connection outright
+   with `"too many L2 streams requested in a single session"` even with message-size chunking,
+   because the cap is on *total concurrent channels for the whole session*, not per message — many
+   chunks running concurrently still open that many channels cumulatively. Fix:
+   **`ORDER_ROUTER_MAX_SYMBOLS_PER_EXCHANGE`**, a per-exchange total-symbol cap (format
+   `"coinbase:25,other:100"`) applied before chunking, truncating (with a logged warning) rather
+   than subscribing past a known session limit.
+
+None of these limits are documented anywhere reliable per-exchange — they were found empirically,
+the same way `skip-tests.json` accumulates exchange quirks in the main ccxt repo. Expect to tune
+`ORDER_ROUTER_MAX_SYMBOLS_PER_EXCHANGE` further per exchange under real production load; this is
+not a solved, closed problem, it's a starting point validated against live connections.
 
 ### Why single-process Node instead of splitting collector (TS) and API (e.g. Rust) via Redis
 
@@ -50,37 +102,28 @@ separate Rust API layer reading from Redis for speed. The math doesn't favor it:
 
 Redis becomes worth it only for **horizontal scaling across hosts**, not raw speed — and even then,
 each API replica should keep its own in-memory copy of the cache, updated **asynchronously** via
-Redis pub/sub in the background (never queried synchronously per-request):
+Redis pub/sub in the background (never queried synchronously per-request). This service's own
+sharding (below) already establishes that pattern using Node's built-in IPC instead of Redis, since
+sharding today is same-host; swapping the transport for cross-host Redis pub/sub later, keeping the
+same "write path is async, read path is always local" shape, is a natural extension, not a rewrite.
 
-```
-Collector(s) --publish--> Redis pub/sub --async subscribe--> API replica 1 (own in-process Map)
-                                         --async subscribe--> API replica 2 (own in-process Map)
-```
-
-Under that pattern the API layer could legitimately be a different language later (including
-Rust) without paying a per-request Redis cost — but only build this once request volume actually
-requires multiple replicas, not preemptively.
-
-### WebSocket connection scale — connection count vs. message throughput
-
-These have very different limits and it's easy to conflate them:
+### Scaling: connection count vs. message throughput vs. single-thread CPU
 
 - **Connection count is not the bottleneck.** ccxt.pro multiplexes: most exchanges get one WS
-  connection per exchange (a few venues cap subscriptions-per-socket, e.g. ~200 streams, forcing a
-  handful of extra connections — ccxt handles this internally). Node's event loop handles
-  thousands of concurrent outbound sockets fine since I/O is async (epoll-backed); the real ceiling
-  is OS file descriptors (`ulimit -n`), trivially raised, not thread count. Going from 5 to 50
-  exchanges, or 2 to 500 symbols, is a non-issue in connection terms.
-- **Aggregate message throughput on the single JS thread is the actual risk.** Every WS message
-  still gets JSON-parsed and diff-merged on one thread. The benchmark above shows KuCoin alone at
-  ~480 msg/s for *one* symbol; many exchanges × many symbols could reach tens of thousands of
-  msg/s aggregate, at which point event-loop lag (and therefore added latency) is real. This needs
-  load-testing with production-scale exchange/symbol counts, not assumption.
-- **Mitigation path, in order of when you'd need it:** (1) already done — push-on-change instead
-  of polling, see above; (2) when profiling shows single-thread CPU is the bottleneck, shard
-  exchanges across multiple OS **processes** (not `worker_threads` sharing one event loop — a CPU
-  spike on one exchange's connector shouldn't add latency to another's), each with its own
-  in-memory cache for its shard.
+  connection per exchange. Node's event loop handles thousands of concurrent outbound sockets fine
+  since I/O is async (epoll-backed); the real ceiling is OS file descriptors (`ulimit -n`),
+  trivially raised, not thread count.
+- **Aggregate message throughput on a single JS thread is the real risk once the routable symbol
+  count is large.** Every WS message still gets JSON-parsed and diff-merged on one thread. At full
+  discovery scale (76 exchanges, thousands of routable symbols) this plausibly exceeds one
+  process's comfortable throughput budget.
+- **Fix: process sharding.** `ORDER_ROUTER_SHARD_COUNT>1` splits the discovered/routable exchange
+  list across `child_process` workers (`src/sharding/`), load-balanced by symbol count (a rough
+  proxy for message rate — no per-symbol throughput data exists yet to balance more precisely).
+  Each shard runs its own connectors and cache; the parent process merges book/health/fee updates
+  from all shards via IPC into the cache the API reads from. A CPU spike in one shard's connector
+  doesn't add latency to another's (separate OS processes, not `worker_threads` sharing one event
+  loop). Not benchmarked yet against real per-shard throughput — see Known gaps.
 
 ## Endpoints
 
@@ -91,28 +134,40 @@ These have very different limits and it's easy to conflate them:
 | GET | `/symbols` | symbols currently cached |
 | GET | `/orderbook/:exchange/:symbol` | cached L2 book snapshot (symbol URL-encoded, e.g. `BTC%2FUSDT`) |
 | GET | `/price/best/:symbol?side=buy\|sell&amount=<qty>` | book-walked, fee-adjusted best execution price across exchanges |
-| WS | `/stream/best/:symbol?side=&amount=` | pushes the same result every 250ms |
+| WS | `/stream/best/:symbol?side=&amount=` | pushes on book change (event-driven, not polled) |
 
 ## Config (env vars)
 
-| Var | Default |
-|---|---|
-| `PORT` | `8080` |
-| `ORDER_ROUTER_EXCHANGES` | `kraken,coinbase,kucoin,bitget,gate` |
-| `ORDER_ROUTER_SYMBOLS` | `BTC/USDT,ETH/USDT` |
-| `ORDER_ROUTER_STALE_BOOK_MS` | `5000` — quotes from books older than this are excluded from ranking |
-| `LOG_LEVEL` | `info` |
+| Var | Default | Notes |
+|---|---|---|
+| `PORT` | `8080` | |
+| `ORDER_ROUTER_DISCOVER_ALL` | `false` | `true` = dynamically discover all exchanges/routable symbols (see Discovery above). `false` = use the explicit lists below. |
+| `ORDER_ROUTER_EXCLUDE_EXCHANGES` | (none) | Comma-separated exchange ids to skip, discovery or explicit mode. |
+| `ORDER_ROUTER_MIN_EXCHANGES_PER_SYMBOL` | `2` | Discovery mode only — symbol must trade on this many exchanges to be routable. |
+| `ORDER_ROUTER_LOAD_MARKETS_CONCURRENCY` | `8` | Discovery mode only — bounded concurrency for the loadMarkets() fan-out. |
+| `ORDER_ROUTER_MAX_SYMBOLS_PER_SUBSCRIPTION` | `50` | Max symbols per `watchOrderBookForSymbols` chunk. |
+| `ORDER_ROUTER_MAX_SYMBOLS_PER_EXCHANGE` | (none) | Per-exchange total-symbol cap, e.g. `"coinbase:25"`. See Subscription mechanics above. |
+| `ORDER_ROUTER_SHARD_COUNT` | `1` | `>1` forks that many child-process shards across the (discovered or explicit) exchange list. |
+| `ORDER_ROUTER_EXCHANGES` | `kraken,coinbase,kucoin,bitget,gate` | Explicit mode only. |
+| `ORDER_ROUTER_SYMBOLS` | `BTC/USDT,ETH/USDT` | Explicit mode only. |
+| `ORDER_ROUTER_STALE_BOOK_MS` | `5000` | Quotes from books older than this are excluded from ranking. |
+| `LOG_LEVEL` | `info` | |
 
 ## Run
 
 ```bash
 npm install
-npm run dev        # tsx watch
+npm run dev        # tsx watch, explicit exchange/symbol list (fast local iteration)
 # or
 npm run build && npm start
+# or full discovery + sharding, e.g. 4 shards:
+ORDER_ROUTER_DISCOVER_ALL=true ORDER_ROUTER_SHARD_COUNT=4 npm start
 # or
 docker compose up --build
 ```
+
+Sharding (`ORDER_ROUTER_SHARD_COUNT>1`) forks compiled `dist/sharding/shardWorker.js` — build first
+(`npm run build`) before using it; `npm run dev` (tsx) does not support sharding today.
 
 ## Benchmark (`benchmark/ws-latency.mjs`)
 
@@ -144,11 +199,18 @@ Coinbase streams close to the full book.
 
 ## Known gaps / next steps
 
-- Re-run the benchmark from unrestricted, NTP-synced infra, including Binance/Bybit/OKX.
+- Re-run the benchmark from unrestricted, NTP-synced infra, including Binance/Bybit/OKX, and at
+  full discovery scale (76 exchanges) rather than the 5-exchange subset reachable from this sandbox.
+- `ORDER_ROUTER_MAX_SYMBOLS_PER_EXCHANGE` needs real per-exchange tuning under production load —
+  the value used in testing (`coinbase:25`) got that one exchange stable but is a starting point,
+  not a researched limit. KuCoin also still showed a nonzero (but much reduced, ~30 vs ~1,500
+  before the fixes) reconnect rate at ~680 routable symbols that wasn't fully root-caused.
+- Shard load-balancing is by symbol count only (a proxy for message rate) — no real per-symbol
+  throughput data exists yet to balance more precisely; revisit once shards are under real load.
 - Order *execution* routing (actually placing orders) is out of scope for this milestone — see
   the repo's live-trading safety rules (25 USD/trade cap, no live `withdraw()` testing) before
   building that; it needs API keys, risk limits, and per-exchange cleanup logic.
-- No Redis/multi-instance story yet — single instance only, by design (see Architecture above).
+- No Redis/cross-host story yet — sharding today is same-host via IPC only (see Architecture).
 - No Prometheus `/metrics` endpoint yet — `/exchanges/status` covers health for now.
 - Depth-limited exchanges (Kraken, Gate, others with capped WS depth) should fall back to REST
   `fetchOrderBook` snapshots when a requested `amount` exceeds cached depth, rather than silently

--- a/order-router/README.md
+++ b/order-router/README.md
@@ -136,6 +136,42 @@ same "write path is async, read path is always local" shape, is a natural extens
 | GET | `/price/best/:symbol?side=buy\|sell&amount=<qty>` | book-walked, fee-adjusted best execution price across exchanges |
 | WS | `/stream/best/:symbol?side=&amount=` | pushes on book change (event-driven, not polled) |
 
+## Security
+
+> **Status: stopgap, not an auth system.** A single shared API key with a hardcoded development
+> fallback. No rotation, no per-client keys, no revocation, no scopes, no TLS termination of its
+> own. It closes the "anyone on the network can read everything" hole; it is not what this should
+> ship with to a real public audience. See Known gaps.
+
+**Authentication** (`src/api/auth.ts`). All routes except `/health` require a key, supplied as
+either `X-API-Key: <key>` or `Authorization: Bearer <key>`.
+
+- `/health` is deliberately unauthenticated so orchestrator liveness probes work before any
+  credential is injectable; it exposes only `status` and process uptime. Everything else —
+  including `/exchanges/status`, which leaks the venue list — is protected.
+- Keys are compared through SHA-256 digests + `timingSafeEqual`, not `===`. Digesting first makes
+  both sides a fixed 32 bytes, so the comparison leaks neither key length nor common prefix
+  through timing, and can't throw on a length mismatch.
+- The auth hook runs at `onRequest`, i.e. **before routing**, so unknown paths return `401` rather
+  than `404` — no oracle for enumerating which routes exist. Missing and wrong keys produce
+  byte-identical responses for the same reason.
+- Unset `ORDER_ROUTER_API_KEY` falls back to the well-known literal `dev-local-key-change-me` and
+  logs a loud warning at startup. That default grants no security; it exists so local dev works
+  and so an unconfigured deployment is obviously wrong rather than subtly wrong.
+
+**Rate limiting** (`@fastify/rate-limit`). Default 600 requests / 60s.
+
+- Registered *before* the auth hook, so a flood of invalid keys burns rate-limit budget instead of
+  reaching the key comparison unbounded.
+- Bucketed **per API key** (falling back to IP only where no key is present), so one client can't
+  exhaust another's budget and clients behind a shared NAT aren't collectively throttled.
+- `/health` is exempt — a throttled liveness probe reads as an outage to an orchestrator and would
+  trigger restarts under exactly the load where that's worst.
+- Responses carry `x-ratelimit-*` and `retry-after`.
+
+The MCP server authenticates its own callers with the same key and forwards it upstream; without
+that it would be an unauthenticated bypass around the router's auth.
+
 ## MCP server (`src/mcp/`)
 
 A separate process (`npm run mcp` / `npm run mcp:dev`) exposing the same public endpoints as MCP
@@ -185,6 +221,9 @@ against a running router with live exchange data) during development — not jus
 | `ORDER_ROUTER_EXCHANGES` | `kraken,coinbase,kucoin,bitget,gate` | Explicit mode only. |
 | `ORDER_ROUTER_SYMBOLS` | `BTC/USDT,ETH/USDT` | Explicit mode only. |
 | `ORDER_ROUTER_STALE_BOOK_MS` | `5000` | Quotes from books older than this are excluded from ranking. |
+| `ORDER_ROUTER_API_KEY` | `dev-local-key-change-me` | **Set this in any real deployment.** The default grants no security and logs a warning. |
+| `ORDER_ROUTER_RATE_LIMIT_MAX` | `600` | Requests per window, per API key. |
+| `ORDER_ROUTER_RATE_LIMIT_WINDOW_MS` | `60000` | Rate limit window. |
 | `LOG_LEVEL` | `info` | |
 
 ## Run
@@ -231,11 +270,77 @@ lifecycle (reconnect/backoff/jitter against a real socket), discovery's `loadMar
 calls, and sharding's actual `child_process` IPC (verified live, not by an automated test, since
 that requires spawning real subprocesses with real network access).
 
-## Benchmark (`benchmark/ws-latency.mjs`)
+## Continuous integration
 
-`npm run bench:ws` measures WS update rate, message latency, and cached book depth per exchange.
+`.github/workflows/order-router.yml` runs on any change under `order-router/` (and nothing else —
+this service is not part of ccxt's transpile pipeline). On Node 22 it runs `npm ci`, `npm run build`
+(type-check), `npm test` (the offline suite), then two smoke steps that boot the real processes and
+assert over HTTP that `/health` is reachable unauthenticated, that a protected route returns `401`
+without a key and `200` with the right one, that a *wrong* key is still rejected, and that the MCP
+endpoint rejects an unauthenticated JSON-RPC call. Those smoke assertions were verified locally
+before being committed.
 
-### Results from this dev sandbox — read the caveats before trusting these numbers
+## Benchmarks
+
+### `npm run bench:multi-connect` — simultaneous multi-exchange connections
+
+Answers "does this actually hold N live exchange connections at once", which no unit test can.
+Connects to each candidate exchange, holds for a set duration, reports message counts and failures.
+
+**Measured from this sandbox — 34 attempted, 28 connected simultaneously, 75s hold:**
+
+| | |
+|---|---|
+| Connected | **28 / 34** |
+| Total messages | 28,518 (~380 msg/s aggregate) |
+| Errors | 0 on 27 of 28 connected exchanges (lbank: 3) |
+| Peak RSS | 230 MB |
+| Heap used | 62 MB |
+
+Highest-volume: kucoin (14,809 msgs), poloniex (7,500), gate (1,791), htx (676), bitget (563),
+coinbase (493). Median time-to-first-message ~1.8s.
+
+The 6 failures are all explainable, none are router bugs:
+
+| Exchange | Reason |
+|---|---|
+| `mexc` | needs the optional `protobufjs` peer dep to decode WS frames — installable, not yet done |
+| `cex`, `luno` | require API credentials even for public WS |
+| `okx`, `binanceus`, `independentreserve` | no data within 20s — the same egress geo-restriction that blocks Binance/Bybit from this sandbox |
+
+Note this is 28 exchanges × 1 symbol. It validates *connection* concurrency, not the full
+55k-subscription symbol load — that still needs unrestricted infra (see Known gaps).
+
+### `npm run bench:load` — REST API load test
+
+`autocannon` against a **running** router, so numbers include real auth, rate limiting, book
+walking and serialization. Raise `ORDER_ROUTER_RATE_LIMIT_MAX` for the run or you'll measure the
+limiter instead of the service.
+
+**Measured: 50 connections, 8s per scenario, 5 live exchanges cached, 0 non-2xx on every
+authenticated path:**
+
+| Scenario | req/s | p50 | p90 | p99 | max |
+|---|---|---|---|---|---|
+| `/health` (baseline, no auth, no cache read) | 13,779 | 3ms | 5ms | 9ms | 244ms |
+| `/symbols` (iterates whole cache) | 8,138 | 5ms | 7ms | 11ms | 28ms |
+| `/orderbook/:ex/:sym` (map lookup + serialize full book) | 6,628 | 7ms | 9ms | 13ms | 209ms |
+| `/price/best` small order (walks every exchange book) | 6,397 | 7ms | 9ms | 12ms | 254ms |
+| `/price/best` large order (walks deeper) | 4,302 | 11ms | 13ms | 18ms | 292ms |
+| unauthenticated (expect 401) | 13,693 | 3ms | 4ms | 6ms | 179ms |
+
+Two things worth reading off this: the routing work itself is cheap (best-price with a large order
+still clears 4.3k req/s), and **auth rejection is as cheap as `/health`** — so an unauthenticated
+flood costs the server roughly nothing per request and isn't a DoS amplifier.
+
+Caveat: single machine, client and server sharing CPU, so absolute throughput is a floor rather
+than a ceiling, and the `max` outliers (~250ms) include client-side scheduling noise.
+
+### `npm run bench:ws` — per-exchange WS latency and book depth
+
+Measures WS update rate, message latency, and cached book depth per exchange.
+
+#### Results from this dev sandbox — read the caveats before trusting these numbers
 
 1. **Binance, Bybit, OKX were unreachable from this sandbox.** Binance/Bybit REST calls returned
    `451`/`403` geo-compliance blocks; OKX's WS connection timed out. This is specific to this
@@ -259,10 +364,32 @@ Takeaway: Kraken/Gate cap streamed depth at 10/50 levels, which limits how large
 routed confidently before you'd need a periodic REST depth-snapshot fallback for those venues.
 Coinbase streams close to the full book.
 
+## Production readiness
+
+Not ready to expose publicly. Honest status of the blockers:
+
+| Blocker | Status |
+|---|---|
+| No authentication | **Partly closed** — shared-key auth exists and is tested, but it's a stopgap: no rotation, no per-client keys, no revocation, no scopes (see Security) |
+| No rate limiting | **Closed** — per-key limiting, tested, `/health` exempt |
+| Never load tested | **Closed** — see Benchmarks; 4.3k–13.8k req/s depending on endpoint |
+| Never run against many exchanges at once | **Closed for connection concurrency** — 28 simultaneous live exchanges verified. **Still open for full symbol load** (55k subscriptions) |
+| Not in CI | **Closed** — build + tests + boot/auth smoke tests on every change |
+| Binance/Bybit/OKX never live-tested | **Open** — geo-blocked from every environment available here |
+| No TLS, runs plain HTTP | **Open** — assumes a terminating proxy in front; not documented or provisioned |
+| No soak testing | **Open** — longest continuous run is minutes, not hours/days |
+| No metrics/alerting | **Open** — only `/exchanges/status` |
+| No HA/failover | **Open** — a dead process is an outage |
+
 ## Known gaps / next steps
 
 - Re-run the benchmark from unrestricted, NTP-synced infra, including Binance/Bybit/OKX, and at
   full discovery scale (76 exchanges) rather than the 5-exchange subset reachable from this sandbox.
+- Replace shared-key auth with something real (per-client keys + rotation + revocation) before any
+  public exposure, and put TLS termination in front.
+- Install `protobufjs` to unblock `mexc` WS decoding (one dependency; not yet done).
+- Soak test: hours-to-days continuous run with `process.memoryUsage()` tracked, to find leaks and
+  slow connection drift that a 75-second test can't.
 - `ORDER_ROUTER_MAX_SYMBOLS_PER_EXCHANGE` needs real per-exchange tuning under production load —
   the value used in testing (`coinbase:25`) got that one exchange stable but is a starting point,
   not a researched limit. KuCoin also still showed a nonzero (but much reduced, ~30 vs ~1,500

--- a/order-router/README.md
+++ b/order-router/README.md
@@ -28,6 +28,59 @@ ExchangeConnector × N (one per exchange, isolated failure domain, ccxt.pro watc
 - **Per-exchange isolation.** Each `ExchangeConnector` owns its own WS connection(s) and
   reconnects with exponential backoff independently; one exchange misbehaving (rate limit,
   disconnect storm) never affects others or the API.
+- **Push-on-change, not polling.** `OrderBookCache` extends `EventEmitter` and emits
+  `update:<symbol>` whenever a book changes; `/stream/best/:symbol` subscribes to that instead of
+  polling on a fixed interval, coalescing bursts into at most one computed result per event-loop
+  tick via `setImmediate`. A poll-based design costs CPU proportional to `poll_rate x client_count`
+  regardless of whether anything changed — doesn't hold up once client/message volume is large.
+
+### Why single-process Node instead of splitting collector (TS) and API (e.g. Rust) via Redis
+
+Considered and rejected for now: a dedicated TS/ccxt collector process publishing to Redis, with a
+separate Rust API layer reading from Redis for speed. The math doesn't favor it:
+
+- An in-process `Map` read is ~100ns. Even a local (same-host) Redis read is ~0.1–0.3ms once you
+  count the round trip and (de)serialization — 1,000–3,000x slower — and that cost lands on every
+  request if the API queries Redis synchronously.
+- The gain from a Rust HTTP/serialization layer over Node's (Fastify) is on the order of tens of
+  µs per request. That's dwarfed by the Redis tax you'd introduce to get it, and both are dwarfed
+  by exchange WS round-trip time (tens of ms) — the actual latency floor.
+- Splitting also means two more language runtimes, two more build/deploy pipelines, and a
+  cross-language wire protocol, for a net-negative latency change.
+
+Redis becomes worth it only for **horizontal scaling across hosts**, not raw speed — and even then,
+each API replica should keep its own in-memory copy of the cache, updated **asynchronously** via
+Redis pub/sub in the background (never queried synchronously per-request):
+
+```
+Collector(s) --publish--> Redis pub/sub --async subscribe--> API replica 1 (own in-process Map)
+                                         --async subscribe--> API replica 2 (own in-process Map)
+```
+
+Under that pattern the API layer could legitimately be a different language later (including
+Rust) without paying a per-request Redis cost — but only build this once request volume actually
+requires multiple replicas, not preemptively.
+
+### WebSocket connection scale — connection count vs. message throughput
+
+These have very different limits and it's easy to conflate them:
+
+- **Connection count is not the bottleneck.** ccxt.pro multiplexes: most exchanges get one WS
+  connection per exchange (a few venues cap subscriptions-per-socket, e.g. ~200 streams, forcing a
+  handful of extra connections — ccxt handles this internally). Node's event loop handles
+  thousands of concurrent outbound sockets fine since I/O is async (epoll-backed); the real ceiling
+  is OS file descriptors (`ulimit -n`), trivially raised, not thread count. Going from 5 to 50
+  exchanges, or 2 to 500 symbols, is a non-issue in connection terms.
+- **Aggregate message throughput on the single JS thread is the actual risk.** Every WS message
+  still gets JSON-parsed and diff-merged on one thread. The benchmark above shows KuCoin alone at
+  ~480 msg/s for *one* symbol; many exchanges × many symbols could reach tens of thousands of
+  msg/s aggregate, at which point event-loop lag (and therefore added latency) is real. This needs
+  load-testing with production-scale exchange/symbol counts, not assumption.
+- **Mitigation path, in order of when you'd need it:** (1) already done — push-on-change instead
+  of polling, see above; (2) when profiling shows single-thread CPU is the bottleneck, shard
+  exchanges across multiple OS **processes** (not `worker_threads` sharing one event loop — a CPU
+  spike on one exchange's connector shouldn't add latency to another's), each with its own
+  in-memory cache for its shard.
 
 ## Endpoints
 

--- a/order-router/README.md
+++ b/order-router/README.md
@@ -249,7 +249,8 @@ against a running router with live exchange data) during development — not jus
 | `ORDER_ROUTER_RATE_LIMIT_MAX` | `600` | Requests per window, per API key. |
 | `ORDER_ROUTER_RATE_LIMIT_WINDOW_MS` | `60000` | Rate limit window. |
 | `ORDER_ROUTER_WS_MAX_CONNECTIONS_PER_KEY` | `50` | Max concurrent `/stream/best` sockets per API key. |
-| `ORDER_ROUTER_WS_IDLE_TIMEOUT_MS` | `120000` | Heartbeat interval; a socket that misses two beats is terminated. |
+| `ORDER_ROUTER_WS_IDLE_TIMEOUT_MS` | `30000` | Heartbeat interval; a socket that misses two beats is terminated. Must stay below the reverse proxy's `proxy_read_timeout`. |
+| `ORDER_ROUTER_TRUST_PROXY` | `false` | Derive client IP from `X-Forwarded-For`. Enable **only** behind a trusted proxy — see "Deploying behind nginx". |
 | `LOG_LEVEL` | `info` | |
 
 ## Run
@@ -295,6 +296,76 @@ development instead — see git history / PR description): `ExchangeConnector`'s
 lifecycle (reconnect/backoff/jitter against a real socket), discovery's `loadMarkets()` network
 calls, and sharding's actual `child_process` IPC (verified live, not by an automated test, since
 that requires spawning real subprocesses with real network access).
+
+## Deploying behind nginx on a VPS
+
+nginx terminates TLS, so the service does not do TLS itself and there is no certificate handling
+in this codebase. Three things must be configured or the deployment is subtly broken.
+
+**1. Bind to loopback.** Set `HOST=127.0.0.1` (default is `0.0.0.0`). Otherwise the service is
+reachable directly on port 8080, bypassing nginx and therefore bypassing TLS — the API key would
+cross the wire in cleartext to anyone who skips the proxy.
+
+**2. Set `ORDER_ROUTER_TRUST_PROXY=true`.** The rate limiter buckets failed-auth attempts by client
+IP. Behind a proxy every request arrives from nginx's address, so without this **all
+unauthenticated traffic shares one bucket** and one abuser throttles every other client's
+legitimate retries. The flag is opt-in rather than automatic because the opposite mistake is worse:
+turning it on with no proxy in front lets any client set `X-Forwarded-For` itself, mint a fresh
+bucket per request, and bypass rate limiting completely. Only enable it when nginx really is in
+front **and** overwrites the header (`proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for`,
+as below — never pass a client-supplied value through).
+
+**3. Keep the WS heartbeat under `proxy_read_timeout`.** nginx closes an idle upstream connection
+on its own timer (default 60s). `ORDER_ROUTER_WS_IDLE_TIMEOUT_MS` now defaults to 30s for that
+reason. If you raise one, raise the other. This bug hides on liquid pairs — a busy book keeps the
+connection full of real data — and only appears on quiet symbols, where the stream silently drops
+about once a minute.
+
+```nginx
+upstream order_router { server 127.0.0.1:8080; }
+
+server {
+    listen 443 ssl http2;
+    server_name router.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/router.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/router.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://order_router;
+        proxy_set_header Host              $host;
+        # $proxy_add_x_forwarded_for appends the real peer; it does not trust what the client sent.
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # /stream/best needs the upgrade headers; without them the handshake 400s.
+    location /stream/ {
+        proxy_pass http://order_router;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host       $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # Must exceed ORDER_ROUTER_WS_IDLE_TIMEOUT_MS or nginx reaps quiet streams first.
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
+    }
+
+    # /metrics is authenticated, but there is no reason to expose it publicly as well.
+    location /metrics {
+        allow 10.0.0.0/8;   # scraper network
+        deny  all;
+        proxy_pass http://order_router;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}
+```
+
+nginx also gives you a second, IP-level rate limit (`limit_req_zone`) in front of the app's
+per-key limit, and can enforce client certificates or IP allowlists if you want a second factor
+alongside the shared API key. What it does **not** solve: the API key is still a single shared
+secret with no rotation or revocation, so per-client identity remains an open gap.
 
 ## Metrics
 
@@ -434,7 +505,7 @@ Not ready to expose publicly. Honest status of the blockers:
 | Never run against many exchanges at once | **Closed for connection concurrency** — 28 simultaneous live exchanges verified. **Still open for full symbol load** (55k subscriptions) |
 | Not in CI | **Closed** — build + tests + boot/auth smoke tests on every change |
 | Binance/Bybit/OKX never live-tested | **Open** — geo-blocked from every environment available here |
-| No TLS, runs plain HTTP | **Open** — assumes a terminating proxy in front; not documented or provisioned |
+| No TLS, runs plain HTTP | **Closed for a proxied deployment** — nginx terminates TLS; config, loopback binding, `trustProxy` and WS timeout pitfalls documented above. Still no TLS if run without a proxy. |
 | No soak testing | **Open** — longest continuous run is minutes, not hours/days |
 | No metrics/alerting | **Closed for instrumentation** — Prometheus `/metrics` with staleness, reconnect, throughput and event-loop-lag signals. **Still open:** nothing scrapes it and no alerts are wired up; the suggested rules above are untested. |
 | No HA/failover | **Open** — a dead process is an outage |

--- a/order-router/benchmark/load-test.mjs
+++ b/order-router/benchmark/load-test.mjs
@@ -1,0 +1,109 @@
+// Load test for the public REST surface. Measures request latency percentiles and throughput
+// against a *running* order-router, so the numbers include real auth, rate limiting, book
+// walking, and JSON serialization — not a synthetic handler.
+//
+// Usage:
+//   node benchmark/load-test.mjs [--url http://localhost:8080] [--key <apiKey>]
+//                                [--duration 10] [--connections 50] [--symbol BTC/USDT]
+//
+// Rate limiting will dominate the results unless the limit is raised for the run; start the
+// server with a high ORDER_ROUTER_RATE_LIMIT_MAX to measure the service rather than the limiter.
+import autocannon from 'autocannon';
+
+function arg (name, fallback) {
+    const idx = process.argv.indexOf(`--${name}`);
+    return idx !== -1 && process.argv[idx + 1] ? process.argv[idx + 1] : fallback;
+}
+
+const BASE_URL = arg('url', 'http://localhost:8080');
+const API_KEY = arg('key', process.env['ORDER_ROUTER_API_KEY'] ?? 'dev-local-key-change-me');
+const DURATION = Number(arg('duration', '10'));
+const CONNECTIONS = Number(arg('connections', '50'));
+const SYMBOL = arg('symbol', 'BTC/USDT');
+const encodedSymbol = encodeURIComponent(SYMBOL);
+
+const SCENARIOS = [
+    {
+        name: 'health (baseline, unauthenticated, no cache read)',
+        path: '/health',
+        headers: {},
+    },
+    {
+        name: 'symbols (authenticated, iterates whole cache)',
+        path: '/symbols',
+        headers: { 'x-api-key': API_KEY },
+    },
+    {
+        name: 'orderbook (authenticated, single map lookup + serialize full book)',
+        path: `/orderbook/kraken/${encodedSymbol}`,
+        headers: { 'x-api-key': API_KEY },
+    },
+    {
+        name: 'price/best small order (authenticated, walks every exchange book)',
+        path: `/price/best/${encodedSymbol}?side=buy&amount=0.01`,
+        headers: { 'x-api-key': API_KEY },
+    },
+    {
+        name: 'price/best large order (authenticated, walks deeper into books)',
+        path: `/price/best/${encodedSymbol}?side=buy&amount=50`,
+        headers: { 'x-api-key': API_KEY },
+    },
+    {
+        name: 'unauthenticated (should be 401 — measures rejection cost)',
+        path: `/price/best/${encodedSymbol}?side=buy&amount=0.01`,
+        headers: {},
+        expectNon2xx: true,
+    },
+];
+
+function runScenario (scenario) {
+    return new Promise((resolve, reject) => {
+        autocannon({
+            url: `${BASE_URL}${scenario.path}`,
+            connections: CONNECTIONS,
+            duration: DURATION,
+            headers: scenario.headers,
+            // Non-2xx is expected for the auth-rejection scenario; autocannon counts them
+            // separately either way, and we report them explicitly below.
+        }, (err, result) => (err ? reject(err) : resolve(result)));
+    });
+}
+
+console.error(`[load-test] target=${BASE_URL} connections=${CONNECTIONS} duration=${DURATION}s`);
+const report = [];
+
+for (const scenario of SCENARIOS) {
+    console.error(`[load-test] running: ${scenario.name}`);
+    const result = await runScenario(scenario);
+    report.push({
+        scenario: scenario.name,
+        path: scenario.path,
+        requestsPerSecond: Math.round(result.requests.average),
+        latencyMs: {
+            p50: result.latency.p50,
+            p90: result.latency.p90,
+            p99: result.latency.p99,
+            max: result.latency.max,
+        },
+        // 2xx vs non-2xx matters: a fast p99 means nothing if the responses were all 401s or 429s.
+        non2xx: result.non2xx,
+        total: result.requests.total,
+        errors: result.errors,
+        timeouts: result.timeouts,
+        expectNon2xx: Boolean(scenario.expectNon2xx),
+    });
+}
+
+console.log(JSON.stringify(report, null, 2));
+
+console.error('\n[load-test] summary');
+for (const r of report) {
+    const status = r.expectNon2xx
+        ? `${r.non2xx} rejected (expected)`
+        : `${r.non2xx} non-2xx${r.non2xx > 0 ? '  <-- INVESTIGATE (rate limited or erroring)' : ''}`;
+    console.error(
+        `  ${r.scenario}\n`
+        + `    ${r.requestsPerSecond} req/s | p50=${r.latencyMs.p50}ms p90=${r.latencyMs.p90}ms `
+        + `p99=${r.latencyMs.p99}ms max=${r.latencyMs.max}ms | ${status}`,
+    );
+}

--- a/order-router/benchmark/multi-exchange-connect.mjs
+++ b/order-router/benchmark/multi-exchange-connect.mjs
@@ -1,0 +1,138 @@
+// Benchmark/verification: how many exchanges can we hold simultaneous live WS order book
+// connections to, and do they stay healthy? Answers the "does this actually work at scale"
+// question that per-exchange unit tests can't.
+//
+// Usage: node benchmark/multi-exchange-connect.mjs [durationSeconds] [maxExchanges]
+import ccxt from 'ccxt';
+
+const DURATION_MS = Number(process.argv[2] ?? 60) * 1000;
+const MAX_EXCHANGES = Number(process.argv[3] ?? 30);
+const CONNECT_TIMEOUT_MS = 20_000;
+
+// Candidate pool: exchanges that loaded markets successfully in the discovery run from this
+// environment. Loading markets over REST does NOT imply the WS endpoint is reachable (OKX is the
+// standing counter-example), which is exactly what this script measures.
+const CANDIDATES = [
+    'kraken', 'coinbase', 'kucoin', 'bitget', 'gate', 'mexc', 'htx', 'bitmart', 'bingx',
+    'bitrue', 'phemex', 'lbank', 'coinex', 'hitbtc', 'whitebit', 'poloniex', 'xt', 'upbit',
+    'bitfinex', 'cex', 'deribit', 'toobit', 'p2b', 'woo', 'bithumb', 'luno', 'okx',
+    'hyperliquid', 'binanceus', 'independentreserve', 'bitstamp', 'bitvavo', 'exmo', 'gemini',
+];
+
+function sleep (ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// close() rejects every still-pending watch future with ExchangeClosedByUser. Racing a watch
+// against a timeout leaves the losing watch promise unawaited, so that rejection would surface as
+// an unhandled rejection and kill the process at teardown. Attaching a no-op catch keeps the
+// promise "handled" while we ignore its late result.
+function ignoreLateRejection (promise) {
+    promise.catch(() => { /* superseded by timeout or shutdown */ });
+    return promise;
+}
+
+async function tryExchange (exchangeId, deadline) {
+    const state = {
+        exchangeId,
+        connected: false,
+        messages: 0,
+        errors: 0,
+        firstMessageMs: null,
+        lastError: null,
+        symbol: null,
+    };
+    let exchange;
+    try {
+        const ExchangeClass = ccxt.pro[exchangeId];
+        if (!ExchangeClass) {
+            state.lastError = 'no ccxt.pro class';
+            return state;
+        }
+        exchange = new ExchangeClass({ enableRateLimit: true });
+        await exchange.loadMarkets();
+
+        // Pick a liquid symbol this exchange actually lists, preferring majors.
+        const preferred = ['BTC/USDT', 'BTC/USD', 'BTC/USDC', 'ETH/USDT', 'ETH/USD'];
+        const symbol = preferred.find((s) => exchange.markets[s])
+            ?? Object.keys(exchange.markets).find((s) => s.startsWith('BTC/'));
+        if (!symbol) {
+            state.lastError = 'no BTC market found';
+            await exchange.close();
+            return state;
+        }
+        state.symbol = symbol;
+
+        const startedAt = Date.now();
+        // Watch loop until the shared deadline; every iteration counts a live message.
+        while (Date.now() < deadline) {
+            try {
+                const timeLeft = deadline - Date.now();
+                const ob = await Promise.race([
+                    ignoreLateRejection(exchange.watchOrderBook(symbol)),
+                    sleep(Math.min(CONNECT_TIMEOUT_MS, timeLeft)).then(() => 'TIMEOUT'),
+                ]);
+                if (ob === 'TIMEOUT') {
+                    if (!state.connected) {
+                        state.lastError = `no data within ${CONNECT_TIMEOUT_MS}ms`;
+                        break;
+                    }
+                    continue;
+                }
+                if (!state.connected) {
+                    state.connected = true;
+                    state.firstMessageMs = Date.now() - startedAt;
+                }
+                state.messages++;
+            } catch (err) {
+                state.errors++;
+                state.lastError = String(err.message ?? err).slice(0, 120);
+                if (state.errors > 20) break;
+                await sleep(500 + Math.random() * 1000);
+            }
+        }
+    } catch (err) {
+        state.lastError = String(err.message ?? err).slice(0, 120);
+    } finally {
+        try {
+            await exchange?.close();
+        } catch { /* best effort */ }
+    }
+    return state;
+}
+
+// Belt-and-braces: a straggler rejection from any exchange's internal plumbing during teardown
+// must not lose us the whole run's results after minutes of live connection time.
+process.on('unhandledRejection', (reason) => {
+    console.error(`[multi-connect] ignored late unhandled rejection: ${String(reason).slice(0, 120)}`);
+});
+
+const pool = CANDIDATES.slice(0, MAX_EXCHANGES);
+console.error(`[multi-connect] attempting ${pool.length} exchanges simultaneously for ${DURATION_MS / 1000}s...`);
+
+const deadline = Date.now() + DURATION_MS;
+const results = await Promise.all(pool.map((id) => tryExchange(id, deadline)));
+
+const connected = results.filter((r) => r.connected);
+const failed = results.filter((r) => !r.connected);
+const totalMessages = results.reduce((sum, r) => sum + r.messages, 0);
+
+console.log(JSON.stringify({
+    attempted: pool.length,
+    connectedCount: connected.length,
+    failedCount: failed.length,
+    totalMessages,
+    messagesPerSecond: Math.round(totalMessages / (DURATION_MS / 1000)),
+    peakRssMB: Math.round(process.memoryUsage().rss / 1024 / 1024),
+    heapUsedMB: Math.round(process.memoryUsage().heapUsed / 1024 / 1024),
+    connected: connected.map((r) => ({
+        exchangeId: r.exchangeId,
+        symbol: r.symbol,
+        messages: r.messages,
+        errors: r.errors,
+        firstMessageMs: r.firstMessageMs,
+    })).sort((a, b) => b.messages - a.messages),
+    failed: failed.map((r) => ({ exchangeId: r.exchangeId, lastError: r.lastError })),
+}, null, 2));
+
+process.exit(0);

--- a/order-router/benchmark/ws-latency.mjs
+++ b/order-router/benchmark/ws-latency.mjs
@@ -1,0 +1,65 @@
+// Benchmark: WS message latency + order book depth for candidate exchanges.
+// Not part of the ccxt library — a one-off measurement script for the order-router design.
+import ccxt from 'ccxt';
+
+const SYMBOL = 'BTC/USDT';
+const DURATION_MS = 30_000;
+const EXCHANGES = ['kraken', 'coinbase', 'kucoin', 'bitget', 'gate'];
+
+function percentile (sorted, p) {
+    if (sorted.length === 0) return null;
+    const idx = Math.min(sorted.length - 1, Math.floor(p * sorted.length));
+    return sorted[idx];
+}
+
+async function benchOrderBook (exchangeId) {
+    const exchange = new ccxt.pro[exchangeId] ({ enableRateLimit: true });
+    const latencies = [];
+    const depths = [];
+    const start = Date.now();
+    let updates = 0;
+    let error = null;
+    try {
+        while (Date.now() - start < DURATION_MS) {
+            const ob = await exchange.watchOrderBook (SYMBOL);
+            const now = Date.now();
+            if (ob.timestamp) {
+                latencies.push(now - ob.timestamp);
+            }
+            depths.push(Math.min(ob.bids.length, ob.asks.length));
+            updates++;
+        }
+    } catch (e) {
+        error = e.message;
+    } finally {
+        await exchange.close ();
+    }
+    latencies.sort((a, b) => a - b);
+    depths.sort((a, b) => a - b);
+    return {
+        exchangeId,
+        updates,
+        error,
+        latencyMs: {
+            p50: percentile(latencies, 0.5),
+            p95: percentile(latencies, 0.95),
+            p99: percentile(latencies, 0.99),
+            max: latencies[latencies.length - 1] ?? null,
+        },
+        depth: {
+            min: depths[0] ?? null,
+            p50: percentile(depths, 0.5),
+            max: depths[depths.length - 1] ?? null,
+        },
+    };
+}
+
+const results = [];
+for (const id of EXCHANGES) {
+    console.error(`[bench] running ${id} for ${DURATION_MS}ms...`);
+    const r = await benchOrderBook (id);
+    console.error(`[bench] ${id} done:`, JSON.stringify(r));
+    results.push(r);
+}
+
+console.log(JSON.stringify(results, null, 2));

--- a/order-router/docker-compose.yml
+++ b/order-router/docker-compose.yml
@@ -10,3 +10,16 @@ services:
       ORDER_ROUTER_SYMBOLS: "BTC/USDT,ETH/USDT"
       ORDER_ROUTER_STALE_BOOK_MS: "5000"
     restart: unless-stopped
+
+  order-router-mcp:
+    build: .
+    command: ["node", "dist/mcp/server.js"]
+    ports:
+      - "8081:8081"
+    environment:
+      ORDER_ROUTER_API_URL: "http://order-router:8080"
+      ORDER_ROUTER_MCP_PORT: "8081"
+      LOG_LEVEL: "info"
+    depends_on:
+      - order-router
+    restart: unless-stopped

--- a/order-router/docker-compose.yml
+++ b/order-router/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  order-router:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: "8080"
+      LOG_LEVEL: "info"
+      ORDER_ROUTER_EXCHANGES: "kraken,coinbase,kucoin,bitget,gate"
+      ORDER_ROUTER_SYMBOLS: "BTC/USDT,ETH/USDT"
+      ORDER_ROUTER_STALE_BOOK_MS: "5000"
+    restart: unless-stopped

--- a/order-router/docker-compose.yml
+++ b/order-router/docker-compose.yml
@@ -9,6 +9,10 @@ services:
       ORDER_ROUTER_EXCHANGES: "kraken,coinbase,kucoin,bitget,gate"
       ORDER_ROUTER_SYMBOLS: "BTC/USDT,ETH/USDT"
       ORDER_ROUTER_STALE_BOOK_MS: "5000"
+      # Override in any real deployment (compose reads it from your shell/.env). The fallback is
+      # the well-known dev key, which grants no security — see README "Security".
+      ORDER_ROUTER_API_KEY: "${ORDER_ROUTER_API_KEY:-dev-local-key-change-me}"
+      ORDER_ROUTER_RATE_LIMIT_MAX: "600"
     restart: unless-stopped
 
   order-router-mcp:
@@ -19,6 +23,8 @@ services:
     environment:
       ORDER_ROUTER_API_URL: "http://order-router:8080"
       ORDER_ROUTER_MCP_PORT: "8081"
+      # Must match the router's key: used both to authenticate MCP callers and to call upstream.
+      ORDER_ROUTER_API_KEY: "${ORDER_ROUTER_API_KEY:-dev-local-key-change-me}"
       LOG_LEVEL: "info"
     depends_on:
       - order-router

--- a/order-router/package-lock.json
+++ b/order-router/package-lock.json
@@ -8,6 +8,7 @@
       "name": "order-router",
       "version": "0.1.0",
       "dependencies": {
+        "@fastify/rate-limit": "^11.2.0",
         "@fastify/websocket": "^11.0.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "ccxt": "4.5.64",
@@ -18,8 +19,27 @@
       },
       "devDependencies": {
         "@types/node": "^22.9.0",
+        "autocannon": "^8.0.0",
         "tsx": "^4.19.2",
         "typescript": "^5.6.3"
+      }
+    },
+    "node_modules/@assemblyscript/loader": {
+      "version": "0.19.23",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.19.23.tgz",
+      "integrity": "sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -575,6 +595,28 @@
         "ipaddr.js": "^2.1.0"
       }
     },
+    "node_modules/@fastify/rate-limit": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-11.2.0.tgz",
+      "integrity": "sha512-X7osJd4XSvMoejYrnJkSZYYjY1eNYoBqhjlzf1RakC2204qExFqZFTKj5+T7VuzA/iUI9Z3UoSqQRkB2HpG0oQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "fastify-plugin": "^6.0.0",
+        "ip-address": "^10.2.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
     "node_modules/@fastify/websocket": {
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/@fastify/websocket/-/websocket-11.3.0.tgz",
@@ -606,6 +648,25 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@minimistjs/subarg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@minimistjs/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha512-Q/ONBiM2zNeYUy0mVSO44mWWKYM3UHuEK43PKIOzJCbvUnPoMH1K+gk3cf1kgnCVJFlWmddahQQCmrmBGlk9jQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.1.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -807,6 +868,39 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -814,6 +908,41 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/autocannon": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/autocannon/-/autocannon-8.0.0.tgz",
+      "integrity": "sha512-fMMcWc2JPFcUaqHeR6+PbmEpTxCrPZyBUM95oG4w3ngJ8NfBNas/ZXA+pTHXLqJ0UlFVTcy05GC25WxKx/M20A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@minimistjs/subarg": "^1.0.0",
+        "chalk": "^4.1.0",
+        "char-spinner": "^1.0.1",
+        "cli-table3": "^0.6.0",
+        "color-support": "^1.1.1",
+        "cross-argv": "^2.0.0",
+        "form-data": "^4.0.0",
+        "has-async-hooks": "^1.0.0",
+        "hdr-histogram-js": "^3.0.0",
+        "hdr-histogram-percentiles-obj": "^3.0.0",
+        "http-parser-js": "^0.5.2",
+        "hyperid": "^3.0.0",
+        "lodash.chunk": "^4.2.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "manage-path": "^2.0.0",
+        "on-net-listen": "^1.1.1",
+        "pretty-bytes": "^5.4.1",
+        "progress": "^2.0.3",
+        "reinterval": "^1.1.0",
+        "retimer": "^3.0.0",
+        "semver": "^7.3.2",
+        "timestring": "^6.0.0"
+      },
+      "bin": {
+        "autocannon": "autocannon.js"
       }
     },
     "node_modules/avvio": {
@@ -999,11 +1128,94 @@
         }
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
+      "integrity": "sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -1066,6 +1278,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cross-argv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cross-argv/-/cross-argv-2.0.0.tgz",
+      "integrity": "sha512-YIaY9TR5Nxeb8SMdtrU8asWVM4jqJDNDYlKV21LxtYcfNJhp1kEsgSa6qXwXgzN0WQWGODps0+TlGp2xQSHwOg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1104,6 +1323,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -1156,6 +1385,13 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -1199,6 +1435,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1552,6 +1804,46 @@
         "node": ">=20"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1643,11 +1935,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-async-hooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-async-hooks/-/has-async-hooks-1.0.0.tgz",
+      "integrity": "sha512-YF0VPGjkxr7AyyQQNykX8zK4PvtEDsUJAPqwu06UFz1lb6EvI53sPh5H1kWxg8NXI5LsfRCZ8uX9NkYDZBb/mw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1666,6 +1991,28 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hdr-histogram-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-3.0.1.tgz",
+      "integrity": "sha512-l3GSdZL1Jr1C0kyb461tUjEdrRPZr8Qry7jByltf5JGrA0xvqOSrxRBfcrJqqV/AMEtqqhHhC6w8HW0gn76tRQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@assemblyscript/loader": "^0.19.21",
+        "base64-js": "^1.2.0",
+        "pako": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/hdr-histogram-percentiles-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
+      "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/help-me": {
       "version": "5.0.0",
@@ -1700,6 +2047,50 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hyperid": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hyperid/-/hyperid-3.3.0.tgz",
+      "integrity": "sha512-7qhCVT4MJIoEsNcbhglhdmBKb09QtcmJNiIQGq7js/Khf5FtQQ9bzcAuloeqBeee7XD7JqDeve9KNlQya5tSGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "uuid": "^8.3.2",
+        "uuid-parse": "^1.1.0"
+      }
+    },
+    "node_modules/hyperid/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/iconv-lite": {
@@ -1760,6 +2151,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-promise": {
@@ -1858,6 +2259,34 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/manage-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/manage-path/-/manage-path-2.0.0.tgz",
+      "integrity": "sha512-NJhyB+PJYTpxhxZJ3lecIGgh4kwIY2RAh44XvAz9UlqthlQwtPBf62uBVR8XaD8CRuSjQ6TnZH2lNJkbLPZM2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -1993,6 +2422,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-net-listen": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/on-net-listen/-/on-net-listen-1.1.2.tgz",
+      "integrity": "sha512-y1HRYy8s/RlcBvDUwKXSmkODMdx4KSuIvloCnQYJ2LdBBC1asY4HtfhXwe3UWknLakATZDnbzht2Ijw3M1EqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=9.4.0 || ^8.9.4"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2001,6 +2440,13 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -2123,6 +2569,19 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -2147,6 +2606,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -2253,6 +2722,13 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/reinterval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+      "integrity": "sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2270,6 +2746,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/retimer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -2580,6 +3063,34 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2592,6 +3103,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
@@ -2599,6 +3123,16 @@
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/timestring": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/timestring/-/timestring-6.0.0.tgz",
+      "integrity": "sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/toad-cache": {
@@ -2703,6 +3237,24 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuid-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uuid-parse/-/uuid-parse-1.1.0.tgz",
+      "integrity": "sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vary": {

--- a/order-router/package-lock.json
+++ b/order-router/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.9.0",
+        "@types/ws": "^8.18.1",
         "autocannon": "^8.0.0",
         "tsx": "^4.19.2",
         "typescript": "^5.6.3"
@@ -802,6 +803,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/abort-controller": {

--- a/order-router/package-lock.json
+++ b/order-router/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@fastify/websocket": "^11.0.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "ccxt": "4.5.64",
         "fastify": "^5.1.0",
         "pino": "^9.5.0",
-        "pino-pretty": "^11.3.0"
+        "pino-pretty": "^11.3.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.9.0",
@@ -594,6 +596,58 @@
         "ws": "^8.16.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
@@ -707,6 +761,19 @@
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "license": "MIT"
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -789,6 +856,43 @@
       ],
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -827,6 +931,44 @@
         "node": ">=6.14.2"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ccxt": {
       "version": "4.5.64",
       "resolved": "https://registry.npmjs.org/ccxt/-/ccxt-4.5.64.tgz",
@@ -863,6 +1005,28 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -876,6 +1040,46 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -885,6 +1089,32 @@
         "node": "*"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -892,6 +1122,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/duplexify": {
@@ -906,6 +1150,21 @@
         "stream-shift": "^1.0.2"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -913,6 +1172,36 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -957,6 +1246,21 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -973,6 +1277,97 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/fast-copy": {
@@ -1122,6 +1517,27 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-my-way": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
@@ -1134,6 +1550,24 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -1151,11 +1585,138 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/help-me": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
       "license": "MIT"
+    },
+    "node_modules/hono": {
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -1183,6 +1744,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
@@ -1190,6 +1760,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/joycon": {
@@ -1225,6 +1816,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/light-my-request": {
       "version": "6.6.0",
@@ -1263,6 +1860,61 @@
       ],
       "license": "MIT"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -1270,6 +1922,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/node-gyp-build": {
@@ -1284,6 +1951,27 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -1293,6 +1981,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1300,6 +2000,34 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pino": {
@@ -1386,6 +2114,15 @@
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -1411,6 +2148,28 @@
       ],
       "license": "MIT"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -1421,11 +2180,55 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -1484,6 +2287,22 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1535,6 +2354,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
@@ -1563,11 +2388,155 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
@@ -1585,6 +2554,15 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/stream-shift": {
@@ -1632,6 +2610,15 @@
         "node": ">=20"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.23.1",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
@@ -1649,6 +2636,37 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -1672,11 +2690,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -1703,6 +2754,24 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/order-router/package-lock.json
+++ b/order-router/package-lock.json
@@ -15,6 +15,7 @@
         "fastify": "^5.1.0",
         "pino": "^9.5.0",
         "pino-pretty": "^11.3.0",
+        "protobufjs": "^7.6.5",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -743,6 +744,63 @@
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@scure/base": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
@@ -799,7 +857,6 @@
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2293,6 +2350,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/manage-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/manage-path/-/manage-path-2.0.0.tgz",
@@ -2626,6 +2689,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -3232,7 +3318,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/order-router/package-lock.json
+++ b/order-router/package-lock.json
@@ -1,0 +1,1709 @@
+{
+  "name": "order-router",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "order-router",
+      "version": "0.1.0",
+      "dependencies": {
+        "@fastify/websocket": "^11.0.1",
+        "ccxt": "4.5.64",
+        "fastify": "^5.1.0",
+        "pino": "^9.5.0",
+        "pino-pretty": "^11.3.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.9.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.6.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
+      "integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.1.0.tgz",
+      "integrity": "sha512-PxcYtKLbQ8Z+yApiqjK8FwxIwvEj38k2OiLc17u8dkJSlmfi2wHHPaSnaoqBPQqtvF8YVsDgDpP2snDCfFrpfw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^7.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
+      "integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+      "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/websocket": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/websocket/-/websocket-11.3.0.tgz",
+      "integrity": "sha512-g89ag4BCcD9YP5wBZXixzoLnuf5j89p/sXFcfpCiv2pdEkYYukBEoK3heVzqsp0EAtszVDc2BBZG0KZqeAShIA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^4.1.3",
+        "fastify-plugin": "^6.0.0",
+        "ws": "^8.16.0"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.2.0.tgz",
+      "integrity": "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.2.0.tgz",
+      "integrity": "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/starknet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/starknet/-/starknet-2.2.0.tgz",
+      "integrity": "sha512-FPgUFyEgbEG7ewrj9gWUeXpf2b6klBnqcZOSFz6z4ycVCIAeGhNqKQUPlvl2Ka8gfmrbCcdIrImyi+dINr06Uw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~2.2.0",
+        "@noble/hashes": "~2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.2.0.tgz",
+      "integrity": "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/ccxt": {
+      "version": "4.5.64",
+      "resolved": "https://registry.npmjs.org/ccxt/-/ccxt-4.5.64.tgz",
+      "integrity": "sha512-qd4Ub/KNkWxughLleXWbtZU3jKWYOVdP8BnBYWQ9syb3xx1SZ+lxzxoDLubO22Zwwds7lvOGkJ/6F8vz7+9rlw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0",
+        "@scure/bip32": "2.2.0",
+        "@scure/bip39": "2.2.0",
+        "@scure/starknet": "2.2.0",
+        "ws": "8.21.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "bufferutil": "4.1.0"
+      },
+      "peerDependencies": {
+        "protobufjs": "^7.5.3"
+      },
+      "peerDependenciesMeta": {
+        "protobufjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fast-copy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "license": "MIT"
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stringify": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+      "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/fast-uri": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.0.tgz",
+      "integrity": "sha512-ZodJ2cRiLVWGi9IgPb3mbgSqM4CD3LexCHkuv0FfBXHJI1ADfucTD06m6clO2Cy5RZYsw/SiCVl/dyrFI/SYWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.10.0.tgz",
+      "integrity": "sha512-A9L0ziuWGQHgEEVgF3davQ9vbD93IuX+lo2IsxapQmu5b/Y/ynn9m9K5JHt9dvyJXOFc5iN0Zk5GHEOqnzhWjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^7.0.0",
+        "find-my-way": "^9.6.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
+      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-11.3.0.tgz",
+      "integrity": "sha512-oXwn7ICywaZPHmu3epHGU2oJX4nPmKvHvB/bwrJHlGcbEWaVcotkpyVHMKLKmiVryWYByNp0jpgAcXpFJDXJzA==",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.2",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.4.tgz",
+      "integrity": "sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/order-router/package-lock.json
+++ b/order-router/package-lock.json
@@ -15,6 +15,7 @@
         "fastify": "^5.1.0",
         "pino": "^9.5.0",
         "pino-pretty": "^11.3.0",
+        "prom-client": "^15.1.3",
         "protobufjs": "^7.6.5",
         "zod": "^4.4.3"
       },
@@ -738,6 +739,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -1051,6 +1061,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -2691,6 +2707,19 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.6.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
@@ -3211,6 +3240,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/thread-stream": {

--- a/order-router/package.json
+++ b/order-router/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "order-router",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Smart order router: aggregates live order books across exchanges via ccxt and serves best-execution price lookups.",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsx watch src/index.ts",
+    "bench:ws": "node benchmark/ws-latency.mjs"
+  },
+  "dependencies": {
+    "ccxt": "4.5.64",
+    "fastify": "^5.1.0",
+    "@fastify/websocket": "^11.0.1",
+    "pino": "^9.5.0",
+    "pino-pretty": "^11.3.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3",
+    "tsx": "^4.19.2",
+    "@types/node": "^22.9.0"
+  }
+}

--- a/order-router/package.json
+++ b/order-router/package.json
@@ -13,7 +13,7 @@
     "bench:ws": "node benchmark/ws-latency.mjs",
     "bench:load": "node benchmark/load-test.mjs",
     "bench:multi-connect": "node benchmark/multi-exchange-connect.mjs",
-    "test": "tsx --test src/**/*.test.ts"
+    "test": "tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
     "@fastify/rate-limit": "^11.2.0",
@@ -23,6 +23,7 @@
     "fastify": "^5.1.0",
     "pino": "^9.5.0",
     "pino-pretty": "^11.3.0",
+    "prom-client": "^15.1.3",
     "protobufjs": "^7.6.5",
     "zod": "^4.4.3"
   },

--- a/order-router/package.json
+++ b/order-router/package.json
@@ -8,18 +8,23 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
-    "bench:ws": "node benchmark/ws-latency.mjs"
+    "mcp": "node dist/mcp/server.js",
+    "mcp:dev": "tsx watch src/mcp/server.ts",
+    "bench:ws": "node benchmark/ws-latency.mjs",
+    "test": "tsx --test src/**/*.test.ts"
   },
   "dependencies": {
+    "@fastify/websocket": "^11.0.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "ccxt": "4.5.64",
     "fastify": "^5.1.0",
-    "@fastify/websocket": "^11.0.1",
     "pino": "^9.5.0",
-    "pino-pretty": "^11.3.0"
+    "pino-pretty": "^11.3.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "typescript": "^5.6.3",
+    "@types/node": "^22.9.0",
     "tsx": "^4.19.2",
-    "@types/node": "^22.9.0"
+    "typescript": "^5.6.3"
   }
 }

--- a/order-router/package.json
+++ b/order-router/package.json
@@ -23,6 +23,7 @@
     "fastify": "^5.1.0",
     "pino": "^9.5.0",
     "pino-pretty": "^11.3.0",
+    "protobufjs": "^7.6.5",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/order-router/package.json
+++ b/order-router/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.9.0",
+    "@types/ws": "^8.18.1",
     "autocannon": "^8.0.0",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3"

--- a/order-router/package.json
+++ b/order-router/package.json
@@ -11,9 +11,12 @@
     "mcp": "node dist/mcp/server.js",
     "mcp:dev": "tsx watch src/mcp/server.ts",
     "bench:ws": "node benchmark/ws-latency.mjs",
+    "bench:load": "node benchmark/load-test.mjs",
+    "bench:multi-connect": "node benchmark/multi-exchange-connect.mjs",
     "test": "tsx --test src/**/*.test.ts"
   },
   "dependencies": {
+    "@fastify/rate-limit": "^11.2.0",
     "@fastify/websocket": "^11.0.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ccxt": "4.5.64",
@@ -24,6 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.9.0",
+    "autocannon": "^8.0.0",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3"
   }

--- a/order-router/src/api/auth.test.ts
+++ b/order-router/src/api/auth.test.ts
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DEV_API_KEY, extractApiKey, isPublicPath, resolveApiKey, safeCompare } from './auth.js';
+
+test('safeCompare matches identical strings and rejects different ones', () => {
+    assert.equal(safeCompare('secret', 'secret'), true);
+    assert.equal(safeCompare('secret', 'secrez'), false);
+});
+
+test('safeCompare handles differing lengths without throwing', () => {
+    // Naive timingSafeEqual on raw buffers throws on length mismatch; the digest-first approach
+    // must not, or an attacker could DoS/probe with a short key.
+    assert.doesNotThrow(() => safeCompare('a', 'a-much-longer-key'));
+    assert.equal(safeCompare('a', 'a-much-longer-key'), false);
+    assert.equal(safeCompare('', 'nonempty'), false);
+});
+
+test('safeCompare does not treat a prefix as a match', () => {
+    assert.equal(safeCompare('secret', 'secret-extra'), false);
+    assert.equal(safeCompare('secret-extra', 'secret'), false);
+});
+
+test('extractApiKey reads X-API-Key', () => {
+    assert.equal(extractApiKey({ 'x-api-key': 'abc' }), 'abc');
+});
+
+test('extractApiKey reads Authorization: Bearer, case-insensitively', () => {
+    assert.equal(extractApiKey({ authorization: 'Bearer abc' }), 'abc');
+    assert.equal(extractApiKey({ authorization: 'bearer abc' }), 'abc');
+    assert.equal(extractApiKey({ authorization: '  Bearer   abc' }), 'abc');
+});
+
+test('extractApiKey prefers X-API-Key when both are present', () => {
+    assert.equal(extractApiKey({ 'x-api-key': 'from-header', authorization: 'Bearer from-bearer' }), 'from-header');
+});
+
+test('extractApiKey returns undefined for missing/empty/malformed credentials', () => {
+    assert.equal(extractApiKey({}), undefined);
+    assert.equal(extractApiKey({ 'x-api-key': '' }), undefined);
+    assert.equal(extractApiKey({ authorization: 'Basic abc' }), undefined);
+    assert.equal(extractApiKey({ authorization: 'Bearer' }), undefined);
+    assert.equal(extractApiKey({ 'x-api-key': 123 }), undefined);
+});
+
+test('isPublicPath allowlists only /health', () => {
+    assert.equal(isPublicPath('/health'), true);
+    assert.equal(isPublicPath('/symbols'), false);
+    assert.equal(isPublicPath('/exchanges/status'), false);
+    assert.equal(isPublicPath('/price/best/BTC%2FUSDT'), false);
+});
+
+test('isPublicPath ignores the query string rather than matching on it', () => {
+    assert.equal(isPublicPath('/health?probe=1'), true);
+    // A protected path must not become public by appending a query that mentions /health.
+    assert.equal(isPublicPath('/symbols?redirect=/health'), false);
+});
+
+test('resolveApiKey falls back to the dev key and flags it as default', () => {
+    const previous = process.env['ORDER_ROUTER_API_KEY'];
+    delete process.env['ORDER_ROUTER_API_KEY'];
+    try {
+        const resolved = resolveApiKey();
+        assert.equal(resolved.apiKey, DEV_API_KEY);
+        assert.equal(resolved.isDefault, true);
+    } finally {
+        if (previous !== undefined) process.env['ORDER_ROUTER_API_KEY'] = previous;
+    }
+});
+
+test('resolveApiKey prefers a configured key and flags it as non-default', () => {
+    const previous = process.env['ORDER_ROUTER_API_KEY'];
+    process.env['ORDER_ROUTER_API_KEY'] = 'configured-production-key';
+    try {
+        const resolved = resolveApiKey();
+        assert.equal(resolved.apiKey, 'configured-production-key');
+        assert.equal(resolved.isDefault, false);
+    } finally {
+        if (previous === undefined) delete process.env['ORDER_ROUTER_API_KEY'];
+        else process.env['ORDER_ROUTER_API_KEY'] = previous;
+    }
+});

--- a/order-router/src/api/auth.ts
+++ b/order-router/src/api/auth.ts
@@ -1,0 +1,72 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+
+// Hardcoded development default. This is deliberately a well-known, obviously-fake value so that
+// running unconfigured is safe-by-obviousness rather than safe-by-accident: it grants no security
+// at all, and the server logs a loud warning when it's in use. Production MUST set
+// ORDER_ROUTER_API_KEY. See README "Security" — this is a stopgap for a not-yet-public service,
+// not an auth system (no rotation, no per-client keys, no revocation, no scopes).
+export const DEV_API_KEY = 'dev-local-key-change-me';
+
+// Paths served without authentication. Only liveness: orchestrators (k8s, ECS, compose
+// healthchecks) probe this before any credential is injectable, and it exposes nothing but
+// process uptime. Everything else — including /exchanges/status, which leaks the venue list —
+// requires a key.
+const PUBLIC_PATHS = new Set(['/health']);
+
+export function isPublicPath (url: string): boolean {
+    // Strip query string before matching so `/health?x=1` can't be used to smuggle a path, and
+    // so a protected path can't be disguised as a public one via a query fragment.
+    const path = url.split('?')[0] ?? '';
+    return PUBLIC_PATHS.has(path);
+}
+
+// Compares via fixed-length SHA-256 digests. timingSafeEqual throws on length mismatch, and
+// comparing raw strings would leak key length (and, with ===, the common prefix) through timing.
+// Digesting first makes both sides always 32 bytes, so the comparison is constant-time with
+// respect to both the length and content of the supplied value.
+export function safeCompare (a: string, b: string): boolean {
+    const digestA = createHash('sha256').update(a, 'utf8').digest();
+    const digestB = createHash('sha256').update(b, 'utf8').digest();
+    return timingSafeEqual(digestA, digestB);
+}
+
+// Accepts either `X-API-Key: <key>` or `Authorization: Bearer <key>`. Two forms because MCP and
+// HTTP clients differ in which they can set conveniently; both are equivalent.
+export function extractApiKey (headers: Record<string, unknown>): string | undefined {
+    const headerKey = headers['x-api-key'];
+    if (typeof headerKey === 'string' && headerKey.length > 0) {
+        return headerKey;
+    }
+    const authorization = headers['authorization'];
+    if (typeof authorization === 'string') {
+        const match = /^Bearer\s+(.+)$/i.exec(authorization.trim());
+        if (match?.[1]) {
+            return match[1];
+        }
+    }
+    return undefined;
+}
+
+export function resolveApiKey (): { apiKey: string; isDefault: boolean } {
+    const configured = process.env['ORDER_ROUTER_API_KEY'];
+    if (configured && configured.length > 0) {
+        return { apiKey: configured, isDefault: false };
+    }
+    return { apiKey: DEV_API_KEY, isDefault: true };
+}
+
+// Fastify onRequest hook. Runs before routing/body parsing so an unauthenticated caller can't
+// reach any handler or spend parse cycles.
+export function makeAuthHook (expectedApiKey: string) {
+    return async function authHook (request: FastifyRequest, reply: FastifyReply): Promise<void> {
+        if (isPublicPath(request.url)) {
+            return;
+        }
+        const provided = extractApiKey(request.headers as Record<string, unknown>);
+        if (provided === undefined || !safeCompare(provided, expectedApiKey)) {
+            // Deliberately does not distinguish "missing" from "wrong" — no oracle for probing.
+            await reply.code(401).send({ error: 'unauthorized' });
+        }
+    };
+}

--- a/order-router/src/api/middleware/auth-bypass.test.ts
+++ b/order-router/src/api/middleware/auth-bypass.test.ts
@@ -1,0 +1,2 @@
+import { test } from 'node:test';
+test('DEPTH3 must fail loudly', () => { throw new Error('DEPTH3 RAN AND FAILED'); });

--- a/order-router/src/api/middleware/auth-bypass.test.ts
+++ b/order-router/src/api/middleware/auth-bypass.test.ts
@@ -1,2 +1,0 @@
-import { test } from 'node:test';
-test('DEPTH3 must fail loudly', () => { throw new Error('DEPTH3 RAN AND FAILED'); });

--- a/order-router/src/api/rateLimiter.test.ts
+++ b/order-router/src/api/rateLimiter.test.ts
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { FixedWindowRateLimiter } from './rateLimiter.js';
+
+test('allows up to max then denies within the window', () => {
+    const limiter = new FixedWindowRateLimiter(3, 60_000);
+    const results = [1, 2, 3, 4, 5].map(() => limiter.consume('k').allowed);
+    assert.deepEqual(results, [true, true, true, false, false]);
+});
+
+test('separate bucket keys have independent budgets', () => {
+    const limiter = new FixedWindowRateLimiter(2, 60_000);
+    limiter.consume('a'); limiter.consume('a');
+    assert.equal(limiter.consume('a').allowed, false);
+    assert.equal(limiter.consume('b').allowed, true, 'a different bucket is unaffected');
+});
+
+test('the window resets after it expires', () => {
+    const limiter = new FixedWindowRateLimiter(1, 1000);
+    const t0 = 1_000_000;
+    assert.equal(limiter.consume('k', t0).allowed, true);
+    assert.equal(limiter.consume('k', t0 + 500).allowed, false, 'still inside the window');
+    assert.equal(limiter.consume('k', t0 + 1500).allowed, true, 'window rolled over');
+});
+
+test('reports limit, remaining and a positive reset', () => {
+    const limiter = new FixedWindowRateLimiter(2, 60_000);
+    const first = limiter.consume('k');
+    assert.equal(first.limit, 2);
+    assert.equal(first.remaining, 1);
+    assert.ok(first.resetSeconds > 0);
+    limiter.consume('k');
+    assert.equal(limiter.consume('k').remaining, 0, 'remaining never goes negative');
+});
+
+test('expired buckets are pruned so attacker-controlled keys cannot grow memory without bound', () => {
+    const limiter = new FixedWindowRateLimiter(10, 1000);
+    const t0 = 1_000_000;
+    for (let i = 0; i < 1200; i++) limiter.consume(`ip-${i}`, t0);
+    assert.ok(limiter.bucketCount > 1000, 'buckets accumulated within the window');
+    limiter.consume('trigger', t0 + 5000);
+    assert.ok(limiter.bucketCount < 100, `expired buckets pruned, got ${limiter.bucketCount}`);
+});

--- a/order-router/src/api/rateLimiter.ts
+++ b/order-router/src/api/rateLimiter.ts
@@ -1,0 +1,64 @@
+// Minimal fixed-window rate limiter for the bare node:http MCP server, which cannot use
+// @fastify/rate-limit. Deliberately mirrors the Fastify limiter's semantics (see
+// src/api/server.ts): bucket by API key only once the key is valid, otherwise by client address,
+// so an attacker rotating the key header cannot mint unlimited fresh buckets.
+//
+// This exists because the MCP endpoint proxies the same privileged data behind the same
+// credential; leaving it unthrottled would have left a second, equivalent brute-force door open
+// after the first was closed.
+
+export interface RateLimitDecision {
+    allowed: boolean;
+    limit: number;
+    remaining: number;
+    resetSeconds: number;
+}
+
+export class FixedWindowRateLimiter {
+    private readonly max: number;
+    private readonly windowMs: number;
+    private buckets = new Map<string, { count: number; expiresAt: number }>();
+
+    constructor (max: number, windowMs: number) {
+        this.max = max;
+        this.windowMs = windowMs;
+    }
+
+    // Drops expired buckets. Bucket keys are partly client-controlled (the IP side), so without
+    // pruning the map would grow without bound under a distributed flood.
+    private prune (now: number): void {
+        for (const [key, bucket] of this.buckets) {
+            if (bucket.expiresAt <= now) {
+                this.buckets.delete(key);
+            }
+        }
+    }
+
+    consume (bucketKey: string, now = Date.now()): RateLimitDecision {
+        // Amortized cleanup: only sweep when the map has grown enough to be worth it, so the
+        // common path stays O(1) rather than O(n) per request.
+        if (this.buckets.size > 1000) {
+            this.prune(now);
+        }
+
+        let bucket = this.buckets.get(bucketKey);
+        if (!bucket || bucket.expiresAt <= now) {
+            bucket = { count: 0, expiresAt: now + this.windowMs };
+            this.buckets.set(bucketKey, bucket);
+        }
+        bucket.count += 1;
+
+        const resetSeconds = Math.max(1, Math.ceil((bucket.expiresAt - now) / 1000));
+        return {
+            allowed: bucket.count <= this.max,
+            limit: this.max,
+            remaining: Math.max(0, this.max - bucket.count),
+            resetSeconds,
+        };
+    }
+
+    // Exposed for tests asserting the pruning behaviour.
+    get bucketCount (): number {
+        return this.buckets.size;
+    }
+}

--- a/order-router/src/api/server.test.ts
+++ b/order-router/src/api/server.test.ts
@@ -282,3 +282,37 @@ test('unauthenticated requests with no key at all are rate limited', async () =>
     assert.ok(codes.includes(429), `unauthenticated flood must be throttled, got ${JSON.stringify(codes)}`);
     await app.close();
 });
+
+// --- WebSocket stream endpoint input validation ---
+
+test('WS /stream/best rejects a non-numeric, negative, or zero amount', async () => {
+    // The WS path originally took Number(amount) unchecked while the REST path validated it.
+    // NaN defeats walkBook's `remaining <= 0` termination check, so it traversed every level of
+    // every book and then streamed nulls — repeatedly, on every book update. Needs a real
+    // listening server (not inject()) because the bug lives in the upgrade handler.
+    const { WebSocket } = await import('ws');
+    const previous = process.env['ORDER_ROUTER_API_KEY'];
+    process.env['ORDER_ROUTER_API_KEY'] = TEST_API_KEY;
+    const app = await buildServer(new OrderBookCache(), new FeeRegistry(), silentLogger, { rateLimitMax: 100000 });
+    try {
+        await app.listen({ port: 0, host: '127.0.0.1' });
+        const address = app.server.address();
+        const port = typeof address === 'object' && address ? address.port : 0;
+
+        for (const bad of ['amount=abc', 'amount=-5', 'amount=0']) {
+            const closeCode = await new Promise<number>((resolve) => {
+                const ws = new WebSocket(`ws://127.0.0.1:${port}/stream/best/BTC%2FUSDT?${bad}`, {
+                    headers: { 'x-api-key': TEST_API_KEY },
+                });
+                ws.on('close', (code: number) => resolve(code));
+                ws.on('error', () => resolve(-1));
+                setTimeout(() => { ws.close(); resolve(0); }, 2000);
+            });
+            assert.equal(closeCode, 1008, `${bad} should be rejected with a policy-violation close`);
+        }
+    } finally {
+        await app.close();
+        if (previous === undefined) delete process.env['ORDER_ROUTER_API_KEY'];
+        else process.env['ORDER_ROUTER_API_KEY'] = previous;
+    }
+});

--- a/order-router/src/api/server.test.ts
+++ b/order-router/src/api/server.test.ts
@@ -503,3 +503,67 @@ test('unresponsive WS clients are reaped by the heartbeat', async () => {
         await app.close();
     }
 });
+
+// --- Reverse-proxy (nginx) deployment behaviour ---
+
+test('without trustProxy, a spoofed X-Forwarded-For cannot mint fresh rate-limit buckets', async () => {
+    // The dangerous direction: if trustProxy were on by default and no proxy overwrote the header,
+    // any client could rotate X-Forwarded-For per request and bypass rate limiting entirely —
+    // handing back the exact brute-force hole the limiter exists to close.
+    const previous = process.env['ORDER_ROUTER_API_KEY'];
+    process.env['ORDER_ROUTER_API_KEY'] = TEST_API_KEY;
+    const app = await buildServer(new OrderBookCache(), new FeeRegistry(), silentLogger, {
+        rateLimitMax: 3,
+        trustProxy: false,
+    });
+    try {
+        const codes: number[] = [];
+        for (let i = 0; i < 6; i++) {
+            const response = await app.inject({
+                method: 'GET',
+                url: '/symbols',
+                headers: { 'x-api-key': 'wrong', 'x-forwarded-for': `10.0.0.${i}` },
+            });
+            codes.push(response.statusCode);
+        }
+        assert.ok(codes.includes(429), 'rotating X-Forwarded-For must NOT evade the limiter');
+    } finally {
+        await app.close();
+        if (previous === undefined) delete process.env['ORDER_ROUTER_API_KEY'];
+        else process.env['ORDER_ROUTER_API_KEY'] = previous;
+    }
+});
+
+test('with trustProxy, distinct forwarded client IPs get independent buckets', async () => {
+    // The nginx direction: without this, every request arrives from the proxy's address and all
+    // unauthenticated traffic shares one bucket, so one abuser throttles every other client.
+    const previous = process.env['ORDER_ROUTER_API_KEY'];
+    process.env['ORDER_ROUTER_API_KEY'] = TEST_API_KEY;
+    const app = await buildServer(new OrderBookCache(), new FeeRegistry(), silentLogger, {
+        rateLimitMax: 2,
+        trustProxy: true,
+    });
+    try {
+        const exhaust = async (ip: string) => {
+            const codes: number[] = [];
+            for (let i = 0; i < 3; i++) {
+                const response = await app.inject({
+                    method: 'GET',
+                    url: '/symbols',
+                    headers: { 'x-api-key': 'wrong', 'x-forwarded-for': ip },
+                });
+                codes.push(response.statusCode);
+            }
+            return codes;
+        };
+        const first = await exhaust('203.0.113.10');
+        assert.equal(first[2], 429, 'first client exhausts its own bucket');
+
+        const second = await exhaust('203.0.113.99');
+        assert.equal(second[0], 401, 'a different forwarded IP starts with a fresh bucket');
+    } finally {
+        await app.close();
+        if (previous === undefined) delete process.env['ORDER_ROUTER_API_KEY'];
+        else process.env['ORDER_ROUTER_API_KEY'] = previous;
+    }
+});

--- a/order-router/src/api/server.test.ts
+++ b/order-router/src/api/server.test.ts
@@ -242,3 +242,43 @@ test('rate limit buckets are per API key, not global', async () => {
         await app.close();
     }
 });
+
+test('failed auth attempts are themselves rate limited (key brute-force is throttled)', async () => {
+    // Regression test for a real bug: registering the auth hook with a bare app.addHook placed it
+    // AHEAD of @fastify/rate-limit's deferred hook, so every 401 short-circuited before the
+    // limiter counted it — leaving API key brute-force completely unthrottled while authenticated
+    // traffic appeared correctly limited. Asserting only the authenticated case (as the original
+    // tests did) cannot catch this.
+    const { app } = await buildRateLimitedServer(5);
+    const codes: number[] = [];
+    for (let i = 0; i < 12; i++) {
+        const response = await app.inject({ method: 'GET', url: '/symbols', headers: { 'x-api-key': 'wrong-key' } });
+        codes.push(response.statusCode);
+    }
+    assert.ok(codes.includes(429), `repeated bad keys must eventually 429, got ${JSON.stringify(codes)}`);
+    await app.close();
+});
+
+test('rotating the API key does not mint unlimited fresh rate-limit buckets', async () => {
+    // The limiter buckets by the attacker-supplied key header. If a fresh key value always got a
+    // fresh bucket, an attacker could rotate the header per request and brute-force without limit.
+    const { app } = await buildRateLimitedServer(5);
+    const codes: number[] = [];
+    for (let i = 0; i < 15; i++) {
+        const response = await app.inject({ method: 'GET', url: '/symbols', headers: { 'x-api-key': `guess-${i}` } });
+        codes.push(response.statusCode);
+    }
+    assert.ok(codes.includes(429), `rotating keys must still be throttled, got ${JSON.stringify(codes)}`);
+    await app.close();
+});
+
+test('unauthenticated requests with no key at all are rate limited', async () => {
+    const { app } = await buildRateLimitedServer(5);
+    const codes: number[] = [];
+    for (let i = 0; i < 12; i++) {
+        const response = await app.inject({ method: 'GET', url: '/symbols' });
+        codes.push(response.statusCode);
+    }
+    assert.ok(codes.includes(429), `unauthenticated flood must be throttled, got ${JSON.stringify(codes)}`);
+    await app.close();
+});

--- a/order-router/src/api/server.test.ts
+++ b/order-router/src/api/server.test.ts
@@ -364,3 +364,142 @@ test('rejected WebSocket upgrades do not leak server-side sockets', async () => 
         else process.env['ORDER_ROUTER_API_KEY'] = previous;
     }
 });
+
+// --- WebSocket connection limits (security finding #4b) ---
+
+async function buildWsLimitedServer (opts: { wsMaxConnectionsPerKey?: number; wsIdleTimeoutMs?: number }) {
+    process.env['ORDER_ROUTER_API_KEY'] = TEST_API_KEY;
+    const cache = new OrderBookCache();
+    cache.setBook(book());
+    const app = await buildServer(cache, new FeeRegistry(), silentLogger, {
+        rateLimitMax: 100000,
+        ...opts,
+    });
+    await app.listen({ port: 0, host: '127.0.0.1' });
+    const address = app.server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+    return { app, port, cache };
+}
+
+test('concurrent WS stream connections are capped per API key', async () => {
+    // Each stream holds a cache listener removed only on close, which the client controls. Rate
+    // limiting bounds how fast connections open, not how many stay open, so without a cap an
+    // authenticated client can accumulate listeners until the process exhausts resources.
+    const { WebSocket } = await import('ws');
+    const { app, port } = await buildWsLimitedServer({ wsMaxConnectionsPerKey: 3 });
+    const open: InstanceType<typeof WebSocket>[] = [];
+    try {
+        const connect = (key: string) => new Promise<{ ok: boolean; code: number }>((resolve) => {
+            const ws = new WebSocket(`ws://127.0.0.1:${port}/stream/best/BTC%2FUSDT?amount=1`, {
+                headers: { 'x-api-key': key },
+            });
+            open.push(ws);
+            let sawData = false;
+            ws.on('message', (d: Buffer) => {
+                const parsed = JSON.parse(d.toString());
+                if (parsed.error === undefined) { sawData = true; resolve({ ok: true, code: 0 }); }
+            });
+            ws.on('close', (code: number) => resolve({ ok: sawData, code }));
+            ws.on('error', () => resolve({ ok: false, code: -1 }));
+        });
+
+        const accepted = [];
+        for (let i = 0; i < 3; i++) accepted.push(await connect(TEST_API_KEY));
+        assert.ok(accepted.every((r) => r.ok), 'first 3 connections within the cap are accepted');
+
+        const rejected = await connect(TEST_API_KEY);
+        assert.equal(rejected.ok, false, 'connection past the cap is rejected');
+        assert.equal(rejected.code, 1013, 'rejected with 1013 Try Again Later');
+    } finally {
+        for (const ws of open) { try { ws.terminate(); } catch { /* already closed */ } }
+        await app.close();
+    }
+});
+
+test('closing a stream frees its slot against the cap', async () => {
+    // Guards the release path: a leaked count would permanently lock a legitimate client out of
+    // its own budget, turning the DoS defence into a self-inflicted DoS.
+    const { WebSocket } = await import('ws');
+    const { app, port } = await buildWsLimitedServer({ wsMaxConnectionsPerKey: 1 });
+    try {
+        const openOne = () => new Promise<InstanceType<typeof WebSocket>>((resolve, reject) => {
+            const ws = new WebSocket(`ws://127.0.0.1:${port}/stream/best/BTC%2FUSDT?amount=1`, {
+                headers: { 'x-api-key': TEST_API_KEY },
+            });
+            ws.on('message', () => resolve(ws));
+            ws.on('error', reject);
+            setTimeout(() => reject(new Error('timeout')), 3000);
+        });
+
+        const first = await openOne();
+        first.close();
+        await new Promise((r) => setTimeout(r, 300));
+
+        // Slot must be reusable now; if the count leaked this rejects with 1013.
+        const second = await openOne();
+        assert.equal(second.readyState, second.OPEN, 'slot was released and reused');
+        second.terminate();
+    } finally {
+        await app.close();
+    }
+});
+
+test('per-key WS caps are independent across keys', async () => {
+    const { WebSocket } = await import('ws');
+    const { app, port } = await buildWsLimitedServer({ wsMaxConnectionsPerKey: 1 });
+    const open: InstanceType<typeof WebSocket>[] = [];
+    try {
+        // Both use the valid key header value here; a different *valid* identity isn't available
+        // under single-key auth, so this asserts the bookkeeping is keyed at all rather than global.
+        const ws = new WebSocket(`ws://127.0.0.1:${port}/stream/best/BTC%2FUSDT?amount=1`, {
+            headers: { 'x-api-key': TEST_API_KEY },
+        });
+        open.push(ws);
+        await new Promise((resolve, reject) => {
+            ws.on('message', resolve);
+            ws.on('error', reject);
+            setTimeout(() => reject(new Error('timeout')), 3000);
+        });
+        // A second connection on the SAME key must be refused at cap 1.
+        const refusedCode = await new Promise<number>((resolve) => {
+            const ws2 = new WebSocket(`ws://127.0.0.1:${port}/stream/best/BTC%2FUSDT?amount=1`, {
+                headers: { 'x-api-key': TEST_API_KEY },
+            });
+            open.push(ws2);
+            ws2.on('close', (code: number) => resolve(code));
+            ws2.on('error', () => resolve(-1));
+        });
+        assert.equal(refusedCode, 1013);
+    } finally {
+        for (const w of open) { try { w.terminate(); } catch { /* already closed */ } }
+        await app.close();
+    }
+});
+
+test('unresponsive WS clients are reaped by the heartbeat', async () => {
+    // A socket that never sends a close frame (half-open TCP, suspended client) would otherwise
+    // hold its listener and cap slot forever. Uses a short idle timeout and suppresses the
+    // client's automatic pong so it looks dead to the server.
+    const { WebSocket } = await import('ws');
+    const { app, port } = await buildWsLimitedServer({ wsMaxConnectionsPerKey: 5, wsIdleTimeoutMs: 250 });
+    try {
+        const ws = new WebSocket(`ws://127.0.0.1:${port}/stream/best/BTC%2FUSDT?amount=1`, {
+            headers: { 'x-api-key': TEST_API_KEY },
+        });
+        await new Promise((resolve, reject) => {
+            ws.on('message', resolve);
+            ws.on('error', reject);
+            setTimeout(() => reject(new Error('timeout')), 3000);
+        });
+        // Silence the automatic pong so the server sees no liveness signal.
+        ws.pong = () => { /* deliberately unresponsive */ };
+
+        const closed = await new Promise<boolean>((resolve) => {
+            ws.on('close', () => resolve(true));
+            setTimeout(() => resolve(false), 4000);
+        });
+        assert.equal(closed, true, 'unresponsive socket must be terminated by the reaper');
+    } finally {
+        await app.close();
+    }
+});

--- a/order-router/src/api/server.test.ts
+++ b/order-router/src/api/server.test.ts
@@ -316,3 +316,51 @@ test('WS /stream/best rejects a non-numeric, negative, or zero amount', async ()
         else process.env['ORDER_ROUTER_API_KEY'] = previous;
     }
 });
+
+test('rejected WebSocket upgrades do not leak server-side sockets', async () => {
+    // Regression test for a confirmed unauthenticated FD-exhaustion DoS. When auth ran at
+    // onRequest, its 401 set reply.sent, which halts Fastify's hook chain — so @fastify/websocket's
+    // own onRequest hook (the one that sets request.ws) never ran, its onResponse cleanup
+    // (`if (request.ws) ...destroy()`) no-oped, and the socket Node had already handed off via the
+    // upgrade event was held for the life of the process. No timeout reaps a post-upgrade socket.
+    // Measured on the original code: 1200 upgrades leaked 1200 FDs in ~700ms.
+    //
+    // Must drive a real TCP upgrade: app.inject() never touches the socket path where this lives.
+    const net = await import('node:net');
+    const previous = process.env['ORDER_ROUTER_API_KEY'];
+    process.env['ORDER_ROUTER_API_KEY'] = TEST_API_KEY;
+    const app = await buildServer(new OrderBookCache(), new FeeRegistry(), silentLogger, { rateLimitMax: 100000 });
+    try {
+        await app.listen({ port: 0, host: '127.0.0.1' });
+        const address = app.server.address();
+        const port = typeof address === 'object' && address ? address.port : 0;
+
+        const upgrade = (path: string) => new Promise<void>((resolve) => {
+            const socket = net.connect(port, '127.0.0.1', () => {
+                socket.write(
+                    `GET ${path} HTTP/1.1\r\nHost: h\r\nUpgrade: websocket\r\n`
+                    + 'Connection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n'
+                    + 'Sec-WebSocket-Version: 13\r\n\r\n');
+            });
+            let buf = '';
+            socket.on('data', (d) => { buf += d; if (buf.includes('\r\n\r\n')) { socket.destroy(); resolve(); } });
+            socket.on('error', () => resolve());
+            socket.setTimeout(3000, () => { socket.destroy(); resolve(); });
+        });
+
+        // Path-independent on the original bug: matched WS route, matched non-WS route, and an
+        // unmatched path all leaked, so all three are covered here.
+        for (const path of ['/stream/best/BTC%2FUSDT', '/symbols', '/nonexistent']) {
+            for (let i = 0; i < 10; i++) await upgrade(path);
+        }
+        await new Promise((r) => setTimeout(r, 1500));
+
+        const held = await new Promise<number>((resolve, reject) =>
+            app.server.getConnections((e, c) => (e ? reject(e) : resolve(c))));
+        assert.ok(held <= 2, `rejected upgrades must not accumulate sockets, ${held} still held`);
+    } finally {
+        await app.close();
+        if (previous === undefined) delete process.env['ORDER_ROUTER_API_KEY'];
+        else process.env['ORDER_ROUTER_API_KEY'] = previous;
+    }
+});

--- a/order-router/src/api/server.test.ts
+++ b/order-router/src/api/server.test.ts
@@ -1,0 +1,108 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import pino from 'pino';
+import { OrderBookCache } from '../cache/orderBookCache.js';
+import { FeeRegistry } from '../cache/feeRegistry.js';
+import { buildServer } from './server.js';
+import type { CachedOrderBook } from '../types.js';
+
+const silentLogger = pino({ level: 'silent' });
+
+function book (overrides: Partial<CachedOrderBook> = {}): CachedOrderBook {
+    return {
+        exchangeId: 'kraken',
+        symbol: 'BTC/USDT',
+        bids: [{ price: 100, amount: 5 }],
+        asks: [{ price: 101, amount: 5 }],
+        exchangeTimestamp: Date.now(),
+        receivedAt: Date.now(),
+        sequence: 1,
+        ...overrides,
+    };
+}
+
+async function buildTestServer () {
+    const cache = new OrderBookCache();
+    const feeRegistry = new FeeRegistry();
+    const app = await buildServer(cache, feeRegistry, silentLogger);
+    return { app, cache, feeRegistry };
+}
+
+test('GET /health returns ok', async () => {
+    const { app } = await buildTestServer();
+    const response = await app.inject({ method: 'GET', url: '/health' });
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json().status, 'ok');
+    await app.close();
+});
+
+test('GET /symbols reflects the cache contents', async () => {
+    const { app, cache } = await buildTestServer();
+    cache.setBook(book({ symbol: 'BTC/USDT' }));
+    cache.setBook(book({ symbol: 'ETH/USDT', exchangeId: 'coinbase' }));
+
+    const response = await app.inject({ method: 'GET', url: '/symbols' });
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(new Set(response.json().symbols), new Set(['BTC/USDT', 'ETH/USDT']));
+    await app.close();
+});
+
+test('GET /exchanges/status reflects recorded health', async () => {
+    const { app, cache } = await buildTestServer();
+    cache.initHealth('kraken');
+    cache.recordUpdate('kraken');
+
+    const response = await app.inject({ method: 'GET', url: '/exchanges/status' });
+    assert.equal(response.statusCode, 200);
+    const status = response.json().exchanges.find((e: { exchangeId: string }) => e.exchangeId === 'kraken');
+    assert.equal(status.connected, true);
+    await app.close();
+});
+
+test('GET /orderbook/:exchange/:symbol returns 404 when nothing is cached', async () => {
+    const { app } = await buildTestServer();
+    const response = await app.inject({ method: 'GET', url: '/orderbook/kraken/BTC%2FUSDT' });
+    assert.equal(response.statusCode, 404);
+    await app.close();
+});
+
+test('GET /orderbook/:exchange/:symbol returns the cached book', async () => {
+    const { app, cache } = await buildTestServer();
+    cache.setBook(book());
+
+    const response = await app.inject({ method: 'GET', url: '/orderbook/kraken/BTC%2FUSDT' });
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json().exchangeId, 'kraken');
+    await app.close();
+});
+
+test('GET /price/best/:symbol requires a positive amount', async () => {
+    const { app } = await buildTestServer();
+    const response = await app.inject({ method: 'GET', url: '/price/best/BTC%2FUSDT?side=buy&amount=0' });
+    assert.equal(response.statusCode, 400);
+    await app.close();
+});
+
+test('GET /price/best/:symbol returns a ranked result for a valid request', async () => {
+    const { app, cache, feeRegistry } = await buildTestServer();
+    cache.setBook(book());
+    feeRegistry.setFee('kraken', 'BTC/USDT', 0.001);
+
+    const response = await app.inject({ method: 'GET', url: '/price/best/BTC%2FUSDT?side=buy&amount=1' });
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.best.exchangeId, 'kraken');
+    assert.equal(body.best.fullyFillable, true);
+    await app.close();
+});
+
+test('GET /price/best/:symbol defaults to buy side when side is omitted', async () => {
+    const { app, cache } = await buildTestServer();
+    cache.setBook(book({ asks: [{ price: 101, amount: 1 }], bids: [{ price: 1, amount: 1 }] }));
+
+    const response = await app.inject({ method: 'GET', url: '/price/best/BTC%2FUSDT?amount=1' });
+    const body = response.json();
+    assert.equal(body.side, 'buy');
+    assert.equal(body.best.averagePrice, 101);
+    await app.close();
+});

--- a/order-router/src/api/server.test.ts
+++ b/order-router/src/api/server.test.ts
@@ -21,11 +21,23 @@ function book (overrides: Partial<CachedOrderBook> = {}): CachedOrderBook {
     };
 }
 
+// Every test runs against the real auth + rate-limit stack rather than a stripped-down app, so
+// these integration tests would catch a middleware ordering regression that unit tests can't.
+const TEST_API_KEY = 'test-api-key';
+const AUTH = { 'x-api-key': TEST_API_KEY };
+
 async function buildTestServer () {
-    const cache = new OrderBookCache();
-    const feeRegistry = new FeeRegistry();
-    const app = await buildServer(cache, feeRegistry, silentLogger);
-    return { app, cache, feeRegistry };
+    const previous = process.env['ORDER_ROUTER_API_KEY'];
+    process.env['ORDER_ROUTER_API_KEY'] = TEST_API_KEY;
+    try {
+        const cache = new OrderBookCache();
+        const feeRegistry = new FeeRegistry();
+        const app = await buildServer(cache, feeRegistry, silentLogger);
+        return { app, cache, feeRegistry };
+    } finally {
+        if (previous === undefined) delete process.env['ORDER_ROUTER_API_KEY'];
+        else process.env['ORDER_ROUTER_API_KEY'] = previous;
+    }
 }
 
 test('GET /health returns ok', async () => {
@@ -41,7 +53,7 @@ test('GET /symbols reflects the cache contents', async () => {
     cache.setBook(book({ symbol: 'BTC/USDT' }));
     cache.setBook(book({ symbol: 'ETH/USDT', exchangeId: 'coinbase' }));
 
-    const response = await app.inject({ method: 'GET', url: '/symbols' });
+    const response = await app.inject({ method: 'GET', url: '/symbols', headers: AUTH });
     assert.equal(response.statusCode, 200);
     assert.deepEqual(new Set(response.json().symbols), new Set(['BTC/USDT', 'ETH/USDT']));
     await app.close();
@@ -52,7 +64,7 @@ test('GET /exchanges/status reflects recorded health', async () => {
     cache.initHealth('kraken');
     cache.recordUpdate('kraken');
 
-    const response = await app.inject({ method: 'GET', url: '/exchanges/status' });
+    const response = await app.inject({ method: 'GET', url: '/exchanges/status', headers: AUTH });
     assert.equal(response.statusCode, 200);
     const status = response.json().exchanges.find((e: { exchangeId: string }) => e.exchangeId === 'kraken');
     assert.equal(status.connected, true);
@@ -61,7 +73,7 @@ test('GET /exchanges/status reflects recorded health', async () => {
 
 test('GET /orderbook/:exchange/:symbol returns 404 when nothing is cached', async () => {
     const { app } = await buildTestServer();
-    const response = await app.inject({ method: 'GET', url: '/orderbook/kraken/BTC%2FUSDT' });
+    const response = await app.inject({ method: 'GET', url: '/orderbook/kraken/BTC%2FUSDT', headers: AUTH });
     assert.equal(response.statusCode, 404);
     await app.close();
 });
@@ -70,7 +82,7 @@ test('GET /orderbook/:exchange/:symbol returns the cached book', async () => {
     const { app, cache } = await buildTestServer();
     cache.setBook(book());
 
-    const response = await app.inject({ method: 'GET', url: '/orderbook/kraken/BTC%2FUSDT' });
+    const response = await app.inject({ method: 'GET', url: '/orderbook/kraken/BTC%2FUSDT', headers: AUTH });
     assert.equal(response.statusCode, 200);
     assert.equal(response.json().exchangeId, 'kraken');
     await app.close();
@@ -78,7 +90,7 @@ test('GET /orderbook/:exchange/:symbol returns the cached book', async () => {
 
 test('GET /price/best/:symbol requires a positive amount', async () => {
     const { app } = await buildTestServer();
-    const response = await app.inject({ method: 'GET', url: '/price/best/BTC%2FUSDT?side=buy&amount=0' });
+    const response = await app.inject({ method: 'GET', url: '/price/best/BTC%2FUSDT?side=buy&amount=0', headers: AUTH });
     assert.equal(response.statusCode, 400);
     await app.close();
 });
@@ -88,7 +100,7 @@ test('GET /price/best/:symbol returns a ranked result for a valid request', asyn
     cache.setBook(book());
     feeRegistry.setFee('kraken', 'BTC/USDT', 0.001);
 
-    const response = await app.inject({ method: 'GET', url: '/price/best/BTC%2FUSDT?side=buy&amount=1' });
+    const response = await app.inject({ method: 'GET', url: '/price/best/BTC%2FUSDT?side=buy&amount=1', headers: AUTH });
     assert.equal(response.statusCode, 200);
     const body = response.json();
     assert.equal(body.best.exchangeId, 'kraken');
@@ -100,9 +112,133 @@ test('GET /price/best/:symbol defaults to buy side when side is omitted', async 
     const { app, cache } = await buildTestServer();
     cache.setBook(book({ asks: [{ price: 101, amount: 1 }], bids: [{ price: 1, amount: 1 }] }));
 
-    const response = await app.inject({ method: 'GET', url: '/price/best/BTC%2FUSDT?amount=1' });
+    const response = await app.inject({ method: 'GET', url: '/price/best/BTC%2FUSDT?amount=1', headers: AUTH });
     const body = response.json();
     assert.equal(body.side, 'buy');
     assert.equal(body.best.averagePrice, 101);
     await app.close();
+});
+
+// --- Authentication (integration, through the real hook chain) ---
+
+test('every non-health route rejects a request with no credentials', async () => {
+    const { app } = await buildTestServer();
+    const protectedUrls = [
+        '/symbols',
+        '/exchanges/status',
+        '/orderbook/kraken/BTC%2FUSDT',
+        '/price/best/BTC%2FUSDT?side=buy&amount=1',
+    ];
+    for (const url of protectedUrls) {
+        const response = await app.inject({ method: 'GET', url });
+        assert.equal(response.statusCode, 401, `${url} should require auth`);
+    }
+    await app.close();
+});
+
+test('/health stays reachable without credentials so probes keep working', async () => {
+    const { app } = await buildTestServer();
+    const response = await app.inject({ method: 'GET', url: '/health' });
+    assert.equal(response.statusCode, 200);
+    await app.close();
+});
+
+test('a wrong API key is rejected', async () => {
+    const { app } = await buildTestServer();
+    const response = await app.inject({ method: 'GET', url: '/symbols', headers: { 'x-api-key': 'wrong' } });
+    assert.equal(response.statusCode, 401);
+    await app.close();
+});
+
+test('Authorization: Bearer is accepted as an alternative to X-API-Key', async () => {
+    const { app } = await buildTestServer();
+    const response = await app.inject({
+        method: 'GET',
+        url: '/symbols',
+        headers: { authorization: `Bearer ${TEST_API_KEY}` },
+    });
+    assert.equal(response.statusCode, 200);
+    await app.close();
+});
+
+test('auth rejection does not leak whether the key was missing or merely wrong', async () => {
+    const { app } = await buildTestServer();
+    const missing = await app.inject({ method: 'GET', url: '/symbols' });
+    const wrong = await app.inject({ method: 'GET', url: '/symbols', headers: { 'x-api-key': 'wrong' } });
+    assert.equal(missing.statusCode, wrong.statusCode);
+    assert.deepEqual(missing.json(), wrong.json());
+    await app.close();
+});
+
+test('auth runs before routing, so unknown paths also require credentials', async () => {
+    // Prevents an information leak where 404-vs-401 reveals which routes exist.
+    const { app } = await buildTestServer();
+    const response = await app.inject({ method: 'GET', url: '/definitely-not-a-route' });
+    assert.equal(response.statusCode, 401);
+    await app.close();
+});
+
+// --- Rate limiting ---
+
+async function buildRateLimitedServer (max: number) {
+    const previous = process.env['ORDER_ROUTER_API_KEY'];
+    process.env['ORDER_ROUTER_API_KEY'] = TEST_API_KEY;
+    try {
+        const cache = new OrderBookCache();
+        const feeRegistry = new FeeRegistry();
+        const app = await buildServer(cache, feeRegistry, silentLogger, { rateLimitMax: max });
+        return { app, cache };
+    } finally {
+        if (previous === undefined) delete process.env['ORDER_ROUTER_API_KEY'];
+        else process.env['ORDER_ROUTER_API_KEY'] = previous;
+    }
+}
+
+test('requests beyond the rate limit are rejected with 429', async () => {
+    const { app } = await buildRateLimitedServer(3);
+    const codes: number[] = [];
+    for (let i = 0; i < 5; i++) {
+        const response = await app.inject({ method: 'GET', url: '/symbols', headers: AUTH });
+        codes.push(response.statusCode);
+    }
+    assert.deepEqual(codes.slice(0, 3), [200, 200, 200], 'first 3 within limit');
+    assert.deepEqual(codes.slice(3), [429, 429], 'subsequent requests throttled');
+    await app.close();
+});
+
+test('rate limit responses carry retry-after and limit headers', async () => {
+    const { app } = await buildRateLimitedServer(1);
+    await app.inject({ method: 'GET', url: '/symbols', headers: AUTH });
+    const limited = await app.inject({ method: 'GET', url: '/symbols', headers: AUTH });
+    assert.equal(limited.statusCode, 429);
+    assert.ok(limited.headers['retry-after'] !== undefined, 'retry-after present');
+    assert.ok(limited.headers['x-ratelimit-limit'] !== undefined, 'x-ratelimit-limit present');
+    await app.close();
+});
+
+test('/health is exempt from rate limiting so probes never see a 429', async () => {
+    const { app } = await buildRateLimitedServer(2);
+    for (let i = 0; i < 10; i++) {
+        const response = await app.inject({ method: 'GET', url: '/health' });
+        assert.equal(response.statusCode, 200, `health request ${i} should not be throttled`);
+    }
+    await app.close();
+});
+
+test('rate limit buckets are per API key, not global', async () => {
+    // One client exhausting its budget must not lock out a different key.
+    const { app } = await buildRateLimitedServer(2);
+    try {
+        await app.inject({ method: 'GET', url: '/symbols', headers: AUTH });
+        await app.inject({ method: 'GET', url: '/symbols', headers: AUTH });
+        const throttled = await app.inject({ method: 'GET', url: '/symbols', headers: AUTH });
+        assert.equal(throttled.statusCode, 429, 'first key exhausted');
+
+        // A different (invalid) key hits its own fresh bucket, so it reaches auth and gets 401 —
+        // not 429, which would prove the buckets were shared.
+        const otherKey = await app.inject({ method: 'GET', url: '/symbols', headers: { 'x-api-key': 'another-key' } });
+        assert.equal(otherKey.statusCode, 401, 'separate bucket, so reaches auth rather than the limiter');
+    } finally {
+        await app.close();
+    }
 });

--- a/order-router/src/api/server.ts
+++ b/order-router/src/api/server.ts
@@ -23,6 +23,7 @@ export interface ServerOptions {
     rateLimitWindowMs?: number;
     wsMaxConnectionsPerKey?: number;
     wsIdleTimeoutMs?: number;
+    trustProxy?: boolean;
 }
 
 export async function buildServer (
@@ -31,7 +32,10 @@ export async function buildServer (
     logger: Logger,
     options: ServerOptions = {},
 ) {
-    const app = Fastify({ loggerInstance: logger });
+    // trustProxy makes request.ip read X-Forwarded-For instead of the socket address. Required for
+    // the limiter's IP bucketing to mean anything behind nginx; dangerous if enabled without a
+    // proxy that overwrites the header (see config.ts). Off by default.
+    const app = Fastify({ loggerInstance: logger, trustProxy: options.trustProxy ?? config.trustProxy });
 
     const rateLimitMax = options.rateLimitMax ?? config.rateLimitMax;
     const rateLimitWindowMs = options.rateLimitWindowMs ?? config.rateLimitWindowMs;

--- a/order-router/src/api/server.ts
+++ b/order-router/src/api/server.ts
@@ -1,12 +1,13 @@
 import Fastify from 'fastify';
 import websocketPlugin from '@fastify/websocket';
 import rateLimit from '@fastify/rate-limit';
+import fastifyPlugin from 'fastify-plugin';
 import type { Logger } from 'pino';
 import { config } from '../config.js';
 import type { OrderBookCache } from '../cache/orderBookCache.js';
 import type { FeeRegistry } from '../cache/feeRegistry.js';
 import { computeBestPrice } from '../routing/bestPrice.js';
-import { extractApiKey, isPublicPath, makeAuthHook, resolveApiKey } from './auth.js';
+import { extractApiKey, isPublicPath, makeAuthHook, resolveApiKey, safeCompare } from './auth.js';
 
 interface BestPriceQuery {
     side?: string;
@@ -39,16 +40,27 @@ export async function buildServer (
         );
     }
 
-    // Rate limit before auth so that unauthenticated brute-force attempts are themselves capped:
-    // registering it first puts its onRequest hook ahead of the auth hook in the lifecycle, so a
-    // flood of bad keys burns rate-limit budget rather than reaching the comparison unbounded.
+    // Rate limiting runs ahead of auth (see the preValidation note below for why that ordering is
+    // not automatic), so unauthenticated brute-force attempts consume budget rather than probing
+    // the key comparison without limit.
     await app.register(rateLimit, {
         max: rateLimitMax,
         timeWindow: rateLimitWindowMs,
-        // Bucket by API key so one misbehaving client can't consume another's budget, and so
-        // clients behind a shared NAT/egress IP aren't collectively throttled. Falls back to IP
-        // when no key is present (only reachable on /health, which is allowlisted below anyway).
-        keyGenerator: (request) => extractApiKey(request.headers as Record<string, unknown>) ?? request.ip,
+        // Bucket by API key ONLY when the key is actually valid, so one legitimate client can't
+        // consume another's budget and NAT'd clients aren't collectively throttled. Everything
+        // else — wrong key, absent key — buckets by IP.
+        //
+        // Bucketing unconditionally on the caller-supplied header is the trap: an attacker just
+        // rotates the header per request, mints a fresh bucket every time, and brute-forces keys
+        // without ever being throttled. It is also an unbounded-memory vector, since each distinct
+        // attacker-chosen value would allocate its own counter.
+        keyGenerator: (request) => {
+            const provided = extractApiKey(request.headers as Record<string, unknown>);
+            if (provided !== undefined && safeCompare(provided, apiKey)) {
+                return provided;
+            }
+            return request.ip;
+        },
         // Liveness probes must never be throttled — a throttled /health reads as an outage to an
         // orchestrator and would trigger pod restarts under exactly the load where that's worst.
         allowList: (request) => isPublicPath(request.url),
@@ -60,7 +72,31 @@ export async function buildServer (
         },
     });
 
-    app.addHook('onRequest', makeAuthHook(apiKey));
+    // Auth runs at preValidation, NOT onRequest. @fastify/rate-limit attaches its check as a
+    // per-route hook, and route-level onRequest hooks run *after* all instance-level onRequest
+    // hooks — so an instance-level auth hook lands ahead of the limiter no matter what order the
+    // two are registered in. That silently inverts the intended order: every 401 short-circuits
+    // before the limiter counts it, leaving API key brute-force entirely unthrottled while
+    // authenticated traffic still appears correctly limited. preValidation runs after the whole
+    // onRequest chain, so the limiter fires first and failed auth consumes budget.
+    // Verified empirically, and regression-tested in server.test.ts.
+    const authHook = makeAuthHook(apiKey);
+    await app.register(fastifyPlugin(async (instance) => {
+        instance.addHook('preValidation', authHook);
+    }, { name: 'order-router-auth' }));
+
+    // preValidation only runs for *matched* routes, so without this an unknown path would 404
+    // before auth ever ran — handing an unauthenticated caller a 404-vs-401 oracle for
+    // enumerating which routes exist. Re-checking auth here keeps unknown paths indistinguishable
+    // from protected ones for anyone without a key, while still giving authenticated callers a
+    // truthful 404 for a genuine typo.
+    app.setNotFoundHandler(async (request, reply) => {
+        const provided = extractApiKey(request.headers as Record<string, unknown>);
+        if (!isPublicPath(request.url) && (provided === undefined || !safeCompare(provided, apiKey))) {
+            return reply.code(401).send({ error: 'unauthorized' });
+        }
+        return reply.code(404).send({ error: 'not found' });
+    });
 
     await app.register(websocketPlugin);
 

--- a/order-router/src/api/server.ts
+++ b/order-router/src/api/server.ts
@@ -1,18 +1,67 @@
 import Fastify from 'fastify';
 import websocketPlugin from '@fastify/websocket';
+import rateLimit from '@fastify/rate-limit';
 import type { Logger } from 'pino';
 import { config } from '../config.js';
 import type { OrderBookCache } from '../cache/orderBookCache.js';
 import type { FeeRegistry } from '../cache/feeRegistry.js';
 import { computeBestPrice } from '../routing/bestPrice.js';
+import { extractApiKey, isPublicPath, makeAuthHook, resolveApiKey } from './auth.js';
 
 interface BestPriceQuery {
     side?: string;
     amount?: string;
 }
 
-export async function buildServer (cache: OrderBookCache, feeRegistry: FeeRegistry, logger: Logger) {
+export interface ServerOptions {
+    // Overrides for the module-level config defaults. Injected rather than read from the global
+    // config so tests can exercise the real middleware chain at a low limit without mutating
+    // process env (config.ts snapshots env at import time, so env mutation can't reach it).
+    rateLimitMax?: number;
+    rateLimitWindowMs?: number;
+}
+
+export async function buildServer (
+    cache: OrderBookCache,
+    feeRegistry: FeeRegistry,
+    logger: Logger,
+    options: ServerOptions = {},
+) {
     const app = Fastify({ loggerInstance: logger });
+
+    const rateLimitMax = options.rateLimitMax ?? config.rateLimitMax;
+    const rateLimitWindowMs = options.rateLimitWindowMs ?? config.rateLimitWindowMs;
+    const { apiKey, isDefault } = resolveApiKey();
+    if (isDefault) {
+        logger.warn(
+            'ORDER_ROUTER_API_KEY is not set — falling back to the well-known development key. '
+            + 'This grants no security. Set ORDER_ROUTER_API_KEY before exposing this service.',
+        );
+    }
+
+    // Rate limit before auth so that unauthenticated brute-force attempts are themselves capped:
+    // registering it first puts its onRequest hook ahead of the auth hook in the lifecycle, so a
+    // flood of bad keys burns rate-limit budget rather than reaching the comparison unbounded.
+    await app.register(rateLimit, {
+        max: rateLimitMax,
+        timeWindow: rateLimitWindowMs,
+        // Bucket by API key so one misbehaving client can't consume another's budget, and so
+        // clients behind a shared NAT/egress IP aren't collectively throttled. Falls back to IP
+        // when no key is present (only reachable on /health, which is allowlisted below anyway).
+        keyGenerator: (request) => extractApiKey(request.headers as Record<string, unknown>) ?? request.ip,
+        // Liveness probes must never be throttled — a throttled /health reads as an outage to an
+        // orchestrator and would trigger pod restarts under exactly the load where that's worst.
+        allowList: (request) => isPublicPath(request.url),
+        addHeaders: {
+            'x-ratelimit-limit': true,
+            'x-ratelimit-remaining': true,
+            'x-ratelimit-reset': true,
+            'retry-after': true,
+        },
+    });
+
+    app.addHook('onRequest', makeAuthHook(apiKey));
+
     await app.register(websocketPlugin);
 
     app.get('/health', async () => ({ status: 'ok', uptimeSec: process.uptime() }));

--- a/order-router/src/api/server.ts
+++ b/order-router/src/api/server.ts
@@ -56,11 +56,30 @@ export async function buildServer (cache: OrderBookCache, connectors: Map<string
             const symbol = decodeURIComponent(request.params.symbol);
             const side = request.query.side === 'sell' ? 'sell' : 'buy';
             const amount = Number(request.query.amount ?? '0.01');
-            const interval = setInterval(() => {
+
+            // Push-on-change rather than polling: with N clients x a fixed
+            // poll interval, CPU cost scales with N regardless of whether
+            // anything changed, which doesn't hold up at scale. A single
+            // pending-flush flag coalesces bursts (a fast-moving symbol can
+            // emit hundreds of book updates/sec) into at most one computed
+            // result per event-loop tick, still bounded by the connected
+            // socket's own backpressure.
+            let flushPending = false;
+            const flush = () => {
+                flushPending = false;
+                if (socket.readyState !== socket.OPEN) return;
                 const result = computeBestPrice(cache, connectors, symbol, side, amount, config.staleBookMs);
                 socket.send(JSON.stringify(result));
-            }, 250);
-            socket.on('close', () => clearInterval(interval));
+            };
+            const onUpdate = () => {
+                if (flushPending) return;
+                flushPending = true;
+                setImmediate(flush);
+            };
+
+            cache.on(`update:${symbol}`, onUpdate);
+            flush();
+            socket.on('close', () => cache.off(`update:${symbol}`, onUpdate));
         },
     );
 

--- a/order-router/src/api/server.ts
+++ b/order-router/src/api/server.ts
@@ -140,7 +140,20 @@ export async function buildServer (
         (socket, request) => {
             const symbol = decodeURIComponent(request.params.symbol);
             const side = request.query.side === 'sell' ? 'sell' : 'buy';
+
+            // Validate amount exactly as the REST handler does. Previously this path took
+            // Number(...) unchecked, so `amount=abc` produced NaN — which defeats the
+            // `remaining <= 0` termination check in walkBook, making it traverse every level of
+            // every book and then stream {amount: null, filledAmount: null, averagePrice: null}
+            // forever. `amount=-5` and absurd magnitudes were likewise accepted. A streaming
+            // endpoint repeating that work on every book update is strictly worse than the
+            // one-shot REST equivalent, so it needs at least the same validation.
             const amount = Number(request.query.amount ?? '0.01');
+            if (!Number.isFinite(amount) || amount <= 0) {
+                socket.send(JSON.stringify({ error: 'amount query param must be a positive finite number' }));
+                socket.close(1008, 'invalid amount');
+                return;
+            }
 
             // Push-on-change rather than polling: with N clients x a fixed
             // poll interval, CPU cost scales with N regardless of whether

--- a/order-router/src/api/server.ts
+++ b/order-router/src/api/server.ts
@@ -1,0 +1,68 @@
+import Fastify from 'fastify';
+import websocketPlugin from '@fastify/websocket';
+import type { Logger } from 'pino';
+import { config } from '../config.js';
+import type { OrderBookCache } from '../cache/orderBookCache.js';
+import type { ExchangeConnector } from '../connectors/exchangeConnector.js';
+import { computeBestPrice } from '../routing/bestPrice.js';
+
+interface BestPriceQuery {
+    side?: string;
+    amount?: string;
+}
+
+export async function buildServer (cache: OrderBookCache, connectors: Map<string, ExchangeConnector>, logger: Logger) {
+    const app = Fastify({ loggerInstance: logger });
+    await app.register(websocketPlugin);
+
+    app.get('/health', async () => ({ status: 'ok', uptimeSec: process.uptime() }));
+
+    app.get('/exchanges/status', async () => ({ exchanges: cache.getHealth() }));
+
+    app.get('/symbols', async () => ({ symbols: cache.listSymbols() }));
+
+    app.get<{ Params: { exchange: string; symbol: string } }>(
+        '/orderbook/:exchange/:symbol',
+        async (request, reply) => {
+            const { exchange, symbol } = request.params;
+            const decodedSymbol = decodeURIComponent(symbol);
+            const book = cache.getBook(exchange, decodedSymbol);
+            if (!book) {
+                reply.code(404);
+                return { error: `no cached order book for ${exchange}:${decodedSymbol}` };
+            }
+            return book;
+        },
+    );
+
+    app.get<{ Params: { symbol: string }; Querystring: BestPriceQuery }>(
+        '/price/best/:symbol',
+        async (request, reply) => {
+            const symbol = decodeURIComponent(request.params.symbol);
+            const side = request.query.side === 'sell' ? 'sell' : 'buy';
+            const amount = Number(request.query.amount ?? '0');
+            if (!(amount > 0)) {
+                reply.code(400);
+                return { error: 'amount query param must be a positive number' };
+            }
+            return computeBestPrice(cache, connectors, symbol, side, amount, config.staleBookMs);
+        },
+    );
+
+    app.get<{ Params: { symbol: string }; Querystring: BestPriceQuery }>(
+        '/stream/best/:symbol',
+        { websocket: true },
+        (socket, request) => {
+            const symbol = decodeURIComponent(request.params.symbol);
+            const side = request.query.side === 'sell' ? 'sell' : 'buy';
+            const amount = Number(request.query.amount ?? '0.01');
+            const interval = setInterval(() => {
+                const result = computeBestPrice(cache, connectors, symbol, side, amount, config.staleBookMs);
+                socket.send(JSON.stringify(result));
+            }, 250);
+            socket.on('close', () => clearInterval(interval));
+        },
+    );
+
+    return app;
+}

--- a/order-router/src/api/server.ts
+++ b/order-router/src/api/server.ts
@@ -3,7 +3,7 @@ import websocketPlugin from '@fastify/websocket';
 import type { Logger } from 'pino';
 import { config } from '../config.js';
 import type { OrderBookCache } from '../cache/orderBookCache.js';
-import type { ExchangeConnector } from '../connectors/exchangeConnector.js';
+import type { FeeRegistry } from '../cache/feeRegistry.js';
 import { computeBestPrice } from '../routing/bestPrice.js';
 
 interface BestPriceQuery {
@@ -11,7 +11,7 @@ interface BestPriceQuery {
     amount?: string;
 }
 
-export async function buildServer (cache: OrderBookCache, connectors: Map<string, ExchangeConnector>, logger: Logger) {
+export async function buildServer (cache: OrderBookCache, feeRegistry: FeeRegistry, logger: Logger) {
     const app = Fastify({ loggerInstance: logger });
     await app.register(websocketPlugin);
 
@@ -45,7 +45,7 @@ export async function buildServer (cache: OrderBookCache, connectors: Map<string
                 reply.code(400);
                 return { error: 'amount query param must be a positive number' };
             }
-            return computeBestPrice(cache, connectors, symbol, side, amount, config.staleBookMs);
+            return computeBestPrice(cache, feeRegistry, symbol, side, amount, config.staleBookMs);
         },
     );
 
@@ -68,7 +68,7 @@ export async function buildServer (cache: OrderBookCache, connectors: Map<string
             const flush = () => {
                 flushPending = false;
                 if (socket.readyState !== socket.OPEN) return;
-                const result = computeBestPrice(cache, connectors, symbol, side, amount, config.staleBookMs);
+                const result = computeBestPrice(cache, feeRegistry, symbol, side, amount, config.staleBookMs);
                 socket.send(JSON.stringify(result));
             };
             const onUpdate = () => {

--- a/order-router/src/api/server.ts
+++ b/order-router/src/api/server.ts
@@ -20,6 +20,8 @@ export interface ServerOptions {
     // process env (config.ts snapshots env at import time, so env mutation can't reach it).
     rateLimitMax?: number;
     rateLimitWindowMs?: number;
+    wsMaxConnectionsPerKey?: number;
+    wsIdleTimeoutMs?: number;
 }
 
 export async function buildServer (
@@ -32,6 +34,10 @@ export async function buildServer (
 
     const rateLimitMax = options.rateLimitMax ?? config.rateLimitMax;
     const rateLimitWindowMs = options.rateLimitWindowMs ?? config.rateLimitWindowMs;
+    const wsMaxConnectionsPerKey = options.wsMaxConnectionsPerKey ?? config.wsMaxConnectionsPerKey;
+    const wsIdleTimeoutMs = options.wsIdleTimeoutMs ?? config.wsIdleTimeoutMs;
+    // Live count of open /stream/best sockets per API key, enforcing wsMaxConnectionsPerKey.
+    const wsConnectionsByKey = new Map<string, number>();
     const { apiKey, isDefault } = resolveApiKey();
     if (isDefault) {
         logger.warn(
@@ -155,6 +161,20 @@ export async function buildServer (
                 return;
             }
 
+            // Cap concurrent streams per key. Rate limiting bounds how fast connections open, not
+            // how many stay open, and each one costs a cache listener plus recomputation on every
+            // book update for its symbol. Counted per key so one client cannot starve another.
+            const connectionKey = extractApiKey(request.headers as Record<string, unknown>) ?? 'unknown';
+            const openForKey = wsConnectionsByKey.get(connectionKey) ?? 0;
+            if (openForKey >= wsMaxConnectionsPerKey) {
+                socket.send(JSON.stringify({
+                    error: `too many concurrent stream connections (limit ${wsMaxConnectionsPerKey})`,
+                }));
+                socket.close(1013, 'connection limit reached');
+                return;
+            }
+            wsConnectionsByKey.set(connectionKey, openForKey + 1);
+
             // Push-on-change rather than polling: with N clients x a fixed
             // poll interval, CPU cost scales with N regardless of whether
             // anything changed, which doesn't hold up at scale. A single
@@ -175,9 +195,44 @@ export async function buildServer (
                 setImmediate(flush);
             };
 
+            // Heartbeat reaper. A socket that dies without a close frame (half-open TCP, suspended
+            // client) would otherwise hold its listener and its slot against the cap forever, so
+            // liveness is asserted actively rather than waiting for a close that may never arrive.
+            let alive = true;
+            socket.on('pong', () => { alive = true; });
+            const heartbeat = setInterval(() => {
+                if (!alive) {
+                    // terminate(), not close(): an unresponsive peer will not complete a closing
+                    // handshake, so a graceful close could hang indefinitely.
+                    socket.terminate();
+                    return;
+                }
+                alive = false;
+                socket.ping();
+            }, wsIdleTimeoutMs);
+
             cache.on(`update:${symbol}`, onUpdate);
             flush();
-            socket.on('close', () => cache.off(`update:${symbol}`, onUpdate));
+
+            // Idempotent: 'close' can fire after terminate(), and releasing twice would corrupt
+            // the per-key count and eventually lock a legitimate client out of its own budget.
+            let released = false;
+            const release = () => {
+                if (released) return;
+                released = true;
+                clearInterval(heartbeat);
+                cache.off(`update:${symbol}`, onUpdate);
+                const remaining = (wsConnectionsByKey.get(connectionKey) ?? 1) - 1;
+                if (remaining > 0) {
+                    wsConnectionsByKey.set(connectionKey, remaining);
+                } else {
+                    // Delete rather than store 0 — connectionKey is client-supplied, so keeping
+                    // empty entries would let key rotation grow this map without bound.
+                    wsConnectionsByKey.delete(connectionKey);
+                }
+            };
+            socket.on('close', release);
+            socket.on('error', release);
         },
     );
 

--- a/order-router/src/api/server.ts
+++ b/order-router/src/api/server.ts
@@ -8,6 +8,7 @@ import type { OrderBookCache } from '../cache/orderBookCache.js';
 import type { FeeRegistry } from '../cache/feeRegistry.js';
 import { computeBestPrice } from '../routing/bestPrice.js';
 import { extractApiKey, isPublicPath, makeAuthHook, resolveApiKey, safeCompare } from './auth.js';
+import { buildHttpHistogram, buildMetricsRegistry } from '../metrics.js';
 
 interface BestPriceQuery {
     side?: string;
@@ -106,7 +107,39 @@ export async function buildServer (
 
     await app.register(websocketPlugin);
 
+    // Total open /stream/best sockets across all keys, for the gauge.
+    const countWsConnections = () => {
+        let total = 0;
+        for (const n of wsConnectionsByKey.values()) total += n;
+        return total;
+    };
+    const metricsRegistry = buildMetricsRegistry({
+        cache,
+        staleBookMs: config.staleBookMs,
+        getWsConnectionCount: countWsConnections,
+    });
+    const httpDuration = buildHttpHistogram(metricsRegistry);
+
+    app.addHook('onResponse', async (request, reply) => {
+        // Label with the ROUTE TEMPLATE, never the raw URL: /orderbook/:exchange/:symbol has tens
+        // of thousands of concrete values across the routable universe, and one series per symbol
+        // would blow up Prometheus cardinality. Unmatched requests collapse to a single bucket.
+        const route = request.routeOptions?.url ?? 'unmatched';
+        httpDuration.observe(
+            { method: request.method, route, status_code: String(reply.statusCode) },
+            reply.elapsedTime / 1000,
+        );
+    });
+
     app.get('/health', async () => ({ status: 'ok', uptimeSec: process.uptime() }));
+
+    // Authenticated like every other non-health route: it exposes the venue list, traffic volume
+    // and internal health, which is exactly the reconnaissance an attacker wants. Scrapers must
+    // send the API key. Not added to PUBLIC_PATHS for that reason.
+    app.get('/metrics', async (_request, reply) => {
+        reply.header('content-type', metricsRegistry.contentType);
+        return metricsRegistry.metrics();
+    });
 
     app.get('/exchanges/status', async () => ({ exchanges: cache.getHealth() }));
 

--- a/order-router/src/cache/feeRegistry.test.ts
+++ b/order-router/src/cache/feeRegistry.test.ts
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { FeeRegistry } from './feeRegistry.js';
+
+test('getFee returns the fallback when no fee has been set', () => {
+    const registry = new FeeRegistry();
+    assert.equal(registry.getFee('kraken', 'BTC/USDT'), 0.001);
+    assert.equal(registry.getFee('kraken', 'BTC/USDT', 0.02), 0.02);
+});
+
+test('getFee returns the set fee once populated', () => {
+    const registry = new FeeRegistry();
+    registry.setFee('kraken', 'BTC/USDT', 0.0016);
+    assert.equal(registry.getFee('kraken', 'BTC/USDT'), 0.0016);
+});
+
+test('fees are scoped per (exchange, symbol) pair', () => {
+    const registry = new FeeRegistry();
+    registry.setFee('kraken', 'BTC/USDT', 0.001);
+    registry.setFee('coinbase', 'BTC/USDT', 0.005);
+    registry.setFee('kraken', 'ETH/USDT', 0.002);
+
+    assert.equal(registry.getFee('kraken', 'BTC/USDT'), 0.001);
+    assert.equal(registry.getFee('coinbase', 'BTC/USDT'), 0.005);
+    assert.equal(registry.getFee('kraken', 'ETH/USDT'), 0.002);
+});
+
+test('setFee emits a fee event with the full payload (used to relay across shard IPC)', () => {
+    const registry = new FeeRegistry();
+    let received: unknown;
+    registry.on('fee', (msg) => { received = msg; });
+
+    registry.setFee('kraken', 'BTC/USDT', 0.001);
+
+    assert.deepEqual(received, { exchangeId: 'kraken', symbol: 'BTC/USDT', takerFeeRate: 0.001 });
+});

--- a/order-router/src/cache/feeRegistry.ts
+++ b/order-router/src/cache/feeRegistry.ts
@@ -1,0 +1,27 @@
+import { EventEmitter } from 'node:events';
+
+// Taker fees, keyed by (exchange, symbol). Populated directly by ExchangeConnector in
+// single-process mode, or relayed over IPC from shard workers in sharded mode — either way the
+// API layer reads from one shared instance without needing to reach into per-connector state
+// (which isn't possible once connectors live in a different process).
+export class FeeRegistry extends EventEmitter {
+    private fees = new Map<string, number>();
+
+    constructor () {
+        super();
+        this.setMaxListeners(0);
+    }
+
+    private key (exchangeId: string, symbol: string): string {
+        return `${exchangeId}:${symbol}`;
+    }
+
+    setFee (exchangeId: string, symbol: string, takerFeeRate: number): void {
+        this.fees.set(this.key(exchangeId, symbol), takerFeeRate);
+        this.emit('fee', { exchangeId, symbol, takerFeeRate });
+    }
+
+    getFee (exchangeId: string, symbol: string, fallback = 0.001): number {
+        return this.fees.get(this.key(exchangeId, symbol)) ?? fallback;
+    }
+}

--- a/order-router/src/cache/orderBookCache.test.ts
+++ b/order-router/src/cache/orderBookCache.test.ts
@@ -1,0 +1,114 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { OrderBookCache } from './orderBookCache.js';
+import type { CachedOrderBook } from '../types.js';
+
+function book (exchangeId: string, symbol: string): CachedOrderBook {
+    return {
+        exchangeId,
+        symbol,
+        bids: [{ price: 1, amount: 1 }],
+        asks: [{ price: 2, amount: 1 }],
+        exchangeTimestamp: Date.now(),
+        receivedAt: Date.now(),
+        sequence: 1,
+    };
+}
+
+test('getBook returns undefined until a book is set, then returns it', () => {
+    const cache = new OrderBookCache();
+    assert.equal(cache.getBook('kraken', 'BTC/USDT'), undefined);
+    const b = book('kraken', 'BTC/USDT');
+    cache.setBook(b);
+    assert.deepEqual(cache.getBook('kraken', 'BTC/USDT'), b);
+});
+
+test('getBooksForSymbol returns only books for that symbol, across exchanges', () => {
+    const cache = new OrderBookCache();
+    cache.setBook(book('kraken', 'BTC/USDT'));
+    cache.setBook(book('coinbase', 'BTC/USDT'));
+    cache.setBook(book('kraken', 'ETH/USDT'));
+
+    const result = cache.getBooksForSymbol('BTC/USDT');
+    assert.equal(result.length, 2);
+    assert.deepEqual(new Set(result.map((b) => b.exchangeId)), new Set(['kraken', 'coinbase']));
+});
+
+test('listSymbols de-duplicates symbols across exchanges', () => {
+    const cache = new OrderBookCache();
+    cache.setBook(book('kraken', 'BTC/USDT'));
+    cache.setBook(book('coinbase', 'BTC/USDT'));
+    cache.setBook(book('kraken', 'ETH/USDT'));
+
+    assert.deepEqual(new Set(cache.listSymbols()), new Set(['BTC/USDT', 'ETH/USDT']));
+});
+
+test('setBook emits a symbol-scoped update event and a generic book event', () => {
+    const cache = new OrderBookCache();
+    let symbolEventFired = false;
+    let genericEventBook: CachedOrderBook | undefined;
+    cache.on('update:BTC/USDT', () => { symbolEventFired = true; });
+    cache.on('book', (b: CachedOrderBook) => { genericEventBook = b; });
+
+    const b = book('kraken', 'BTC/USDT');
+    cache.setBook(b);
+
+    assert.equal(symbolEventFired, true);
+    assert.deepEqual(genericEventBook, b);
+});
+
+test('setBook does not emit the wrong symbol-scoped event', () => {
+    const cache = new OrderBookCache();
+    let wrongEventFired = false;
+    cache.on('update:ETH/USDT', () => { wrongEventFired = true; });
+
+    cache.setBook(book('kraken', 'BTC/USDT'));
+
+    assert.equal(wrongEventFired, false);
+});
+
+test('health lifecycle: init -> update -> error -> reconnect', () => {
+    const cache = new OrderBookCache();
+    cache.initHealth('kraken');
+    let health = cache.getHealth().find((h) => h.exchangeId === 'kraken');
+    assert.equal(health?.connected, false);
+    assert.equal(health?.updateCount, 0);
+
+    cache.recordUpdate('kraken');
+    health = cache.getHealth().find((h) => h.exchangeId === 'kraken');
+    assert.equal(health?.connected, true);
+    assert.equal(health?.updateCount, 1);
+
+    cache.recordError('kraken', 'boom');
+    health = cache.getHealth().find((h) => h.exchangeId === 'kraken');
+    assert.equal(health?.connected, false);
+    assert.equal(health?.lastError, 'boom');
+
+    cache.recordReconnect('kraken');
+    health = cache.getHealth().find((h) => h.exchangeId === 'kraken');
+    assert.equal(health?.reconnectCount, 1);
+});
+
+test('recordUpdate/recordError/recordReconnect on an unknown exchange is a silent no-op', () => {
+    const cache = new OrderBookCache();
+    // No initHealth() called — none of these should throw.
+    assert.doesNotThrow(() => cache.recordUpdate('ghost'));
+    assert.doesNotThrow(() => cache.recordError('ghost', 'x'));
+    assert.doesNotThrow(() => cache.recordReconnect('ghost'));
+    assert.equal(cache.getHealth().length, 0);
+});
+
+test('setHealth overwrites wholesale (mirrors a shard worker\'s already-computed state)', () => {
+    const cache = new OrderBookCache();
+    cache.setHealth({
+        exchangeId: 'kraken',
+        connected: true,
+        lastUpdateAt: 12345,
+        updateCount: 99,
+        reconnectCount: 3,
+        lastError: undefined,
+    });
+    const health = cache.getHealth().find((h) => h.exchangeId === 'kraken');
+    assert.equal(health?.updateCount, 99);
+    assert.equal(health?.reconnectCount, 3);
+});

--- a/order-router/src/cache/orderBookCache.ts
+++ b/order-router/src/cache/orderBookCache.ts
@@ -1,11 +1,26 @@
+import { EventEmitter } from 'node:events';
 import type { CachedOrderBook, ExchangeHealth } from '../types.js';
 
 // In-process hot-path cache. Reads are plain Map lookups (no network hop) —
 // this is deliberate: a single router instance should never touch Redis on
 // the read path. See order-router/README.md for the multi-instance story.
-export class OrderBookCache {
+//
+// Emits 'update:<symbol>' whenever a book for that symbol changes, so
+// consumers (e.g. the WS stream endpoint) can push on change instead of
+// polling — polling on a fixed interval per connected client wastes CPU
+// proportional to (poll rate x client count) regardless of whether anything
+// changed, which matters once WS message/client volume is large.
+export class OrderBookCache extends EventEmitter {
     private books = new Map<string, CachedOrderBook>();
     private health = new Map<string, ExchangeHealth>();
+
+    constructor () {
+        super();
+        // Each 'update:<symbol>' event can have many WS stream subscribers;
+        // Node's default cap of 10 listeners/event is for leak detection on
+        // typical emitters, not applicable here.
+        this.setMaxListeners(0);
+    }
 
     private key (exchangeId: string, symbol: string): string {
         return `${exchangeId}:${symbol}`;
@@ -13,6 +28,7 @@ export class OrderBookCache {
 
     setBook (book: CachedOrderBook): void {
         this.books.set(this.key(book.exchangeId, book.symbol), book);
+        this.emit(`update:${book.symbol}`);
     }
 
     getBook (exchangeId: string, symbol: string): CachedOrderBook | undefined {

--- a/order-router/src/cache/orderBookCache.ts
+++ b/order-router/src/cache/orderBookCache.ts
@@ -10,6 +10,11 @@ import type { CachedOrderBook, ExchangeHealth } from '../types.js';
 // polling — polling on a fixed interval per connected client wastes CPU
 // proportional to (poll rate x client count) regardless of whether anything
 // changed, which matters once WS message/client volume is large.
+//
+// Also emits generic 'book' and 'health' events (not scoped to one symbol) —
+// used only by a shard worker (see src/sharding/) to relay writes to the
+// parent process's cache over IPC. A non-sharded instance has no listeners
+// on these and pays nothing for them.
 export class OrderBookCache extends EventEmitter {
     private books = new Map<string, CachedOrderBook>();
     private health = new Map<string, ExchangeHealth>();
@@ -29,6 +34,7 @@ export class OrderBookCache extends EventEmitter {
     setBook (book: CachedOrderBook): void {
         this.books.set(this.key(book.exchangeId, book.symbol), book);
         this.emit(`update:${book.symbol}`);
+        this.emit('book', book);
     }
 
     getBook (exchangeId: string, symbol: string): CachedOrderBook | undefined {
@@ -54,23 +60,39 @@ export class OrderBookCache extends EventEmitter {
     }
 
     initHealth (exchangeId: string): void {
-        this.health.set(exchangeId, {
+        const h: ExchangeHealth = {
             exchangeId,
             connected: false,
             lastUpdateAt: undefined,
             updateCount: 0,
             reconnectCount: 0,
             lastError: undefined,
-        });
+        };
+        this.health.set(exchangeId, h);
+        this.emit('health', h);
+    }
+
+    // Overwrites a health record wholesale — used by the parent process in sharded mode to mirror
+    // a shard worker's already-computed health state, rather than recomputing counters locally.
+    setHealth (health: ExchangeHealth): void {
+        this.health.set(health.exchangeId, health);
     }
 
     recordUpdate (exchangeId: string): void {
         const h = this.health.get(exchangeId);
         if (!h) return;
+        const wasDisconnected = !h.connected;
         h.connected = true;
         h.lastUpdateAt = Date.now();
         h.updateCount += 1;
         h.lastError = undefined;
+        // Deliberately not emitted on every call: this runs once per book update, which can be
+        // hundreds/sec for a busy symbol — a shard worker instead flushes health snapshots on a
+        // slow timer (see src/sharding/shardWorker.ts) rather than doubling IPC traffic with a
+        // 'health' event per 'book' event. Reconnect transitions are still emitted immediately.
+        if (wasDisconnected) {
+            this.emit('health', h);
+        }
     }
 
     recordError (exchangeId: string, message: string): void {
@@ -78,12 +100,14 @@ export class OrderBookCache extends EventEmitter {
         if (!h) return;
         h.connected = false;
         h.lastError = message;
+        this.emit('health', h);
     }
 
     recordReconnect (exchangeId: string): void {
         const h = this.health.get(exchangeId);
         if (!h) return;
         h.reconnectCount += 1;
+        this.emit('health', h);
     }
 
     getHealth (): ExchangeHealth[] {

--- a/order-router/src/cache/orderBookCache.ts
+++ b/order-router/src/cache/orderBookCache.ts
@@ -59,6 +59,24 @@ export class OrderBookCache extends EventEmitter {
         return Array.from(symbols);
     }
 
+    getBookCount (): number {
+        return this.books.size;
+    }
+
+    // Books too old to be used for ranking. Uses receivedAt rather than the exchange-supplied
+    // timestamp deliberately: exchange clocks drift and some venues omit the field entirely, so
+    // local arrival time is the only measure that is consistently present and monotonic here.
+    countStaleBooks (staleBookMs: number): number {
+        const cutoff = Date.now() - staleBookMs;
+        let stale = 0;
+        for (const book of this.books.values()) {
+            if (book.receivedAt < cutoff) {
+                stale += 1;
+            }
+        }
+        return stale;
+    }
+
     initHealth (exchangeId: string): void {
         const h: ExchangeHealth = {
             exchangeId,

--- a/order-router/src/cache/orderBookCache.ts
+++ b/order-router/src/cache/orderBookCache.ts
@@ -1,0 +1,76 @@
+import type { CachedOrderBook, ExchangeHealth } from '../types.js';
+
+// In-process hot-path cache. Reads are plain Map lookups (no network hop) —
+// this is deliberate: a single router instance should never touch Redis on
+// the read path. See order-router/README.md for the multi-instance story.
+export class OrderBookCache {
+    private books = new Map<string, CachedOrderBook>();
+    private health = new Map<string, ExchangeHealth>();
+
+    private key (exchangeId: string, symbol: string): string {
+        return `${exchangeId}:${symbol}`;
+    }
+
+    setBook (book: CachedOrderBook): void {
+        this.books.set(this.key(book.exchangeId, book.symbol), book);
+    }
+
+    getBook (exchangeId: string, symbol: string): CachedOrderBook | undefined {
+        return this.books.get(this.key(exchangeId, symbol));
+    }
+
+    getBooksForSymbol (symbol: string): CachedOrderBook[] {
+        const result: CachedOrderBook[] = [];
+        for (const book of this.books.values()) {
+            if (book.symbol === symbol) {
+                result.push(book);
+            }
+        }
+        return result;
+    }
+
+    listSymbols (): string[] {
+        const symbols = new Set<string>();
+        for (const book of this.books.values()) {
+            symbols.add(book.symbol);
+        }
+        return Array.from(symbols);
+    }
+
+    initHealth (exchangeId: string): void {
+        this.health.set(exchangeId, {
+            exchangeId,
+            connected: false,
+            lastUpdateAt: undefined,
+            updateCount: 0,
+            reconnectCount: 0,
+            lastError: undefined,
+        });
+    }
+
+    recordUpdate (exchangeId: string): void {
+        const h = this.health.get(exchangeId);
+        if (!h) return;
+        h.connected = true;
+        h.lastUpdateAt = Date.now();
+        h.updateCount += 1;
+        h.lastError = undefined;
+    }
+
+    recordError (exchangeId: string, message: string): void {
+        const h = this.health.get(exchangeId);
+        if (!h) return;
+        h.connected = false;
+        h.lastError = message;
+    }
+
+    recordReconnect (exchangeId: string): void {
+        const h = this.health.get(exchangeId);
+        if (!h) return;
+        h.reconnectCount += 1;
+    }
+
+    getHealth (): ExchangeHealth[] {
+        return Array.from(this.health.values());
+    }
+}

--- a/order-router/src/config.test.ts
+++ b/order-router/src/config.test.ts
@@ -1,0 +1,2 @@
+import { test } from 'node:test';
+test('DEPTH1 must fail loudly', () => { throw new Error('DEPTH1 RAN AND FAILED'); });

--- a/order-router/src/config.test.ts
+++ b/order-router/src/config.test.ts
@@ -1,2 +1,0 @@
-import { test } from 'node:test';
-test('DEPTH1 must fail loudly', () => { throw new Error('DEPTH1 RAN AND FAILED'); });

--- a/order-router/src/config.ts
+++ b/order-router/src/config.ts
@@ -100,5 +100,21 @@ export const config = {
     // Belt to the cap's braces: reaps sockets that stop responding to pings without cleanly
     // closing (half-open TCP, suspended laptop, hostile client that never sends a close frame).
     // Without it those connections hold their listener slot against the cap indefinitely.
-    wsIdleTimeoutMs: Number(process.env['ORDER_ROUTER_WS_IDLE_TIMEOUT_MS'] ?? 120_000),
+    // 30s, deliberately BELOW nginx's 60s default proxy_read_timeout. A reverse proxy closes an
+    // idle upstream connection on its own timer, so a heartbeat slower than that timer never fires
+    // — the proxy kills the stream first. Only shows up on quiet symbols: an active book keeps the
+    // connection busy with real data, so the bug hides until you subscribe to an illiquid pair.
+    // If you raise proxy_read_timeout, this can rise with it; it must stay under it either way.
+    wsIdleTimeoutMs: Number(process.env['ORDER_ROUTER_WS_IDLE_TIMEOUT_MS'] ?? 30_000),
+
+    // Whether to derive the client IP from X-Forwarded-For. MUST stay false unless a trusted proxy
+    // actually fronts this service and overwrites that header.
+    //
+    // The failure is symmetric, which is why it is opt-in rather than auto-detected:
+    //   - false behind nginx  -> every request appears to come from the proxy, so all unauthenticated
+    //     traffic shares ONE rate-limit bucket and per-client fairness is lost.
+    //   - true when NOT behind a proxy -> any client can set X-Forwarded-For itself, mint a fresh
+    //     bucket per request, and bypass rate limiting entirely. That is strictly worse: it hands
+    //     back the exact brute-force hole the limiter exists to close.
+    trustProxy: process.env['ORDER_ROUTER_TRUST_PROXY'] === 'true',
 };

--- a/order-router/src/config.ts
+++ b/order-router/src/config.ts
@@ -6,14 +6,81 @@ function listFromEnv (name: string, fallback: string[]): string[] {
     return raw.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
 }
 
+function boolFromEnv (name: string, fallback: boolean): boolean {
+    const raw = process.env[name];
+    if (raw === undefined) return fallback;
+    return raw === 'true' || raw === '1';
+}
+
+// Parses "exchangeId:number,exchangeId:number" into a lookup map. Used for per-exchange
+// overrides where a single global default can't be right — see maxSymbolsPerExchangeOverrides.
+function numberMapFromEnv (name: string): Map<string, number> {
+    const raw = process.env[name];
+    const map = new Map<string, number>();
+    if (!raw) return map;
+    for (const pair of raw.split(',')) {
+        const [id, value] = pair.split(':').map((s) => s.trim());
+        if (id && value && !Number.isNaN(Number(value))) {
+            map.set(id, Number(value));
+        }
+    }
+    return map;
+}
+
 export const config = {
     port: Number(process.env['PORT'] ?? 8080),
     host: process.env['HOST'] ?? '0.0.0.0',
-    // Default venue list reflects the WS reachability + book-depth benchmark in benchmark/ws-latency.mjs
-    // run from this dev environment. Binance/Bybit/OKX are typically the deepest/fastest venues in
-    // production and should be added here once benchmarked from unrestricted, NTP-synced infra.
+
+    // When true, discover every ccxt.pro exchange that supports watchOrderBook, load its markets,
+    // and build the routable symbol universe dynamically (see src/discovery/). When false, use the
+    // explicit `exchanges`/`symbols` lists below — the conservative default for local dev, since
+    // discovery mode fans out to ~76 exchanges and can take minutes + hit rate limits on first run.
+    discoverAllExchanges: boolFromEnv('ORDER_ROUTER_DISCOVER_ALL', false),
+
+    // Exchanges to skip during discovery: known geo-blocked/unreachable from a given deployment host,
+    // or exchanges whose loadMarkets/WS is known-broken. Also applied as a filter on the explicit list.
+    excludeExchanges: listFromEnv('ORDER_ROUTER_EXCLUDE_EXCHANGES', []),
+
+    // A symbol is only worth subscribing to if it's tradable on 2+ exchanges — a symbol listed on
+    // exactly one exchange has nothing to route between, so it costs a subscription/memory/CPU for
+    // zero routing value. Raise this to restrict to more-liquid, more-cross-listed symbols.
+    minExchangesPerSymbol: Number(process.env['ORDER_ROUTER_MIN_EXCHANGES_PER_SYMBOL'] ?? 2),
+
+    // Bounded concurrency for the discovery-phase loadMarkets() fan-out, to avoid hammering many
+    // exchanges' REST endpoints simultaneously at startup.
+    loadMarketsConcurrency: Number(process.env['ORDER_ROUTER_LOAD_MARKETS_CONCURRENCY'] ?? 8),
+
+    // Exchanges that support watchOrderBookForSymbols still enforce a server-side cap on how many
+    // symbols/streams one subscription (or one session) can cover — observed directly: Coinbase
+    // ("too many L2 streams requested in a single session"), Bitget ("subscribe over limit,
+    // max:1000"), KuCoin (rejects an overlong comma-joined topic string). A single unchunked
+    // watchOrderBookForSymbols(allSymbols) call trips these once the routable symbol count gets
+    // large. Chunking keeps each subscription well under any of the observed limits; each chunk
+    // runs its own independent watch loop.
+    maxSymbolsPerSubscription: Number(process.env['ORDER_ROUTER_MAX_SYMBOLS_PER_SUBSCRIPTION'] ?? 50),
+
+    // Some exchanges cap total concurrent streams *per session*, not per subscribe message — e.g.
+    // Coinbase rejected our default chunk size outright with "too many L2 streams requested in a
+    // single session" even though each individual chunk was well under the message-size cap,
+    // because running many chunks concurrently still opens that many channels on one connection.
+    // Chunking alone can't fix a session-wide cap; the total symbol count assigned to that
+    // exchange has to come down. No single default is safe here — this is genuinely per-exchange,
+    // discovered empirically (the same way skip-tests.json accumulates known exchange quirks in
+    // the main ccxt repo) rather than documented anywhere reliable. Format: "coinbase:30,foo:100".
+    // Undocumented/unset exchanges get no cap (limited only by maxSymbolsPerSubscription chunking).
+    maxSymbolsPerExchangeOverrides: numberMapFromEnv('ORDER_ROUTER_MAX_SYMBOLS_PER_EXCHANGE'),
+
+    // Number of child-process shards to spread exchange connectors across. Each shard owns a subset
+    // of exchanges and streams book updates to the parent (API) process over Node's built-in IPC
+    // pipe (same-host, no external DB, far cheaper than a Redis round trip). 1 = no sharding, all
+    // connectors run in the main process (fine for a handful of exchanges; not fine for ~76).
+    shardCount: Number(process.env['ORDER_ROUTER_SHARD_COUNT'] ?? 1),
+
+    // Default venue/symbol list used only when discoverAllExchanges is false. Reflects the WS
+    // reachability benchmark in benchmark/ws-latency.mjs run from this dev environment.
     exchanges: listFromEnv('ORDER_ROUTER_EXCHANGES', ['kraken', 'coinbase', 'kucoin', 'bitget', 'gate']),
     symbols: listFromEnv('ORDER_ROUTER_SYMBOLS', ['BTC/USDT', 'ETH/USDT']),
+
     staleBookMs: Number(process.env['ORDER_ROUTER_STALE_BOOK_MS'] ?? 5000),
     logLevel: process.env['LOG_LEVEL'] ?? 'info',
 };

--- a/order-router/src/config.ts
+++ b/order-router/src/config.ts
@@ -1,0 +1,19 @@
+function listFromEnv (name: string, fallback: string[]): string[] {
+    const raw = process.env[name];
+    if (!raw) {
+        return fallback;
+    }
+    return raw.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+export const config = {
+    port: Number(process.env['PORT'] ?? 8080),
+    host: process.env['HOST'] ?? '0.0.0.0',
+    // Default venue list reflects the WS reachability + book-depth benchmark in benchmark/ws-latency.mjs
+    // run from this dev environment. Binance/Bybit/OKX are typically the deepest/fastest venues in
+    // production and should be added here once benchmarked from unrestricted, NTP-synced infra.
+    exchanges: listFromEnv('ORDER_ROUTER_EXCHANGES', ['kraken', 'coinbase', 'kucoin', 'bitget', 'gate']),
+    symbols: listFromEnv('ORDER_ROUTER_SYMBOLS', ['BTC/USDT', 'ETH/USDT']),
+    staleBookMs: Number(process.env['ORDER_ROUTER_STALE_BOOK_MS'] ?? 5000),
+    logLevel: process.env['LOG_LEVEL'] ?? 'info',
+};

--- a/order-router/src/config.ts
+++ b/order-router/src/config.ts
@@ -83,4 +83,11 @@ export const config = {
 
     staleBookMs: Number(process.env['ORDER_ROUTER_STALE_BOOK_MS'] ?? 5000),
     logLevel: process.env['LOG_LEVEL'] ?? 'info',
+
+    // Rate limiting. Applied per API key (falling back to client IP when the key is absent, which
+    // only happens on the unauthenticated /health path). Defaults are deliberately generous — this
+    // is abuse/runaway-client protection, not a quota system; the read path is an in-memory map
+    // lookup, so the server can sustain far more than this.
+    rateLimitMax: Number(process.env['ORDER_ROUTER_RATE_LIMIT_MAX'] ?? 600),
+    rateLimitWindowMs: Number(process.env['ORDER_ROUTER_RATE_LIMIT_WINDOW_MS'] ?? 60_000),
 };

--- a/order-router/src/config.ts
+++ b/order-router/src/config.ts
@@ -90,4 +90,15 @@ export const config = {
     // lookup, so the server can sustain far more than this.
     rateLimitMax: Number(process.env['ORDER_ROUTER_RATE_LIMIT_MAX'] ?? 600),
     rateLimitWindowMs: Number(process.env['ORDER_ROUTER_RATE_LIMIT_WINDOW_MS'] ?? 60_000),
+
+    // WebSocket stream limits. Each /stream/best connection holds an EventEmitter listener on the
+    // cache that is only removed on socket close — which the client controls. Without a cap, an
+    // authenticated client can accumulate connections (and listeners, and per-connection compute on
+    // every book update) until the process exhausts sockets or CPU. Rate limiting does not help:
+    // it bounds the rate of new connections, not the number held open.
+    wsMaxConnectionsPerKey: Number(process.env['ORDER_ROUTER_WS_MAX_CONNECTIONS_PER_KEY'] ?? 50),
+    // Belt to the cap's braces: reaps sockets that stop responding to pings without cleanly
+    // closing (half-open TCP, suspended laptop, hostile client that never sends a close frame).
+    // Without it those connections hold their listener slot against the cap indefinitely.
+    wsIdleTimeoutMs: Number(process.env['ORDER_ROUTER_WS_IDLE_TIMEOUT_MS'] ?? 120_000),
 };

--- a/order-router/src/connectors/exchangeConnector.test.ts
+++ b/order-router/src/connectors/exchangeConnector.test.ts
@@ -1,0 +1,42 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { chunkSymbols, normalizeLevels } from './exchangeConnector.js';
+
+test('chunkSymbols splits into groups no larger than the given size', () => {
+    const symbols = Array.from({ length: 125 }, (_, i) => `SYM${i}`);
+    const chunks = chunkSymbols(symbols, 50);
+
+    assert.equal(chunks.length, 3);
+    assert.equal(chunks[0]?.length, 50);
+    assert.equal(chunks[1]?.length, 50);
+    assert.equal(chunks[2]?.length, 25);
+    assert.deepEqual(chunks.flat(), symbols);
+});
+
+test('chunkSymbols on an empty array returns no chunks', () => {
+    assert.deepEqual(chunkSymbols([], 50), []);
+});
+
+test('chunkSymbols with size >= symbol count returns one chunk', () => {
+    const symbols = ['a', 'b', 'c'];
+    assert.deepEqual(chunkSymbols(symbols, 50), [symbols]);
+});
+
+test('normalizeLevels drops levels missing price or amount', () => {
+    const levels: [number | undefined, number | undefined][] = [
+        [100, 1],
+        [undefined, 1],
+        [100, undefined],
+        [101, 2],
+    ];
+
+    assert.deepEqual(normalizeLevels(levels), [
+        { price: 100, amount: 1 },
+        { price: 101, amount: 2 },
+    ]);
+});
+
+test('normalizeLevels on an all-valid input passes through unchanged', () => {
+    const levels: [number | undefined, number | undefined][] = [[100, 1], [99, 2]];
+    assert.deepEqual(normalizeLevels(levels), [{ price: 100, amount: 1 }, { price: 99, amount: 2 }]);
+});

--- a/order-router/src/connectors/exchangeConnector.ts
+++ b/order-router/src/connectors/exchangeConnector.ts
@@ -1,7 +1,27 @@
 import ccxt, { Exchange, type OrderBook } from 'ccxt';
 import type { OrderBookCache } from '../cache/orderBookCache.js';
 import type { FeeRegistry } from '../cache/feeRegistry.js';
+import type { BookLevel } from '../types.js';
 import type { Logger } from 'pino';
+
+// Pure, unit-testable in isolation from the network/WS machinery below.
+
+export function chunkSymbols (symbols: string[], size: number): string[][] {
+    const chunks: string[][] = [];
+    for (let i = 0; i < symbols.length; i += size) {
+        chunks.push(symbols.slice(i, i + size));
+    }
+    return chunks;
+}
+
+// ccxt's raw [price, amount] tuples type price/amount as possibly-undefined (Num = number |
+// undefined); drop any level missing either before it reaches the cache, which assumes complete
+// numeric levels.
+export function normalizeLevels (levels: [number | undefined, number | undefined][]): BookLevel[] {
+    return levels
+        .filter((level): level is [number, number] => level[0] !== undefined && level[1] !== undefined)
+        .map(([price, amount]) => ({ price, amount }));
+}
 
 const BACKOFF_START_MS = 500;
 const BACKOFF_MAX_MS = 30_000;
@@ -104,10 +124,7 @@ export class ExchangeConnector {
         // maxSymbolsPerSubscription-sized groups, each its own independent watch loop, rather
         // than one unbounded call for every routable symbol on the exchange.
         if (this.exchange.has?.watchOrderBookForSymbols && this.symbols.length > 1) {
-            const chunks: string[][] = [];
-            for (let i = 0; i < this.symbols.length; i += this.maxSymbolsPerSubscription) {
-                chunks.push(this.symbols.slice(i, i + this.maxSymbolsPerSubscription));
-            }
+            const chunks = chunkSymbols(this.symbols, this.maxSymbolsPerSubscription);
             this.logger.info(
                 { symbolCount: this.symbols.length, chunkCount: chunks.length, chunkSize: this.maxSymbolsPerSubscription },
                 'using batched watchOrderBookForSymbols, chunked',
@@ -130,12 +147,8 @@ export class ExchangeConnector {
         this.cache.setBook({
             exchangeId: this.exchangeId,
             symbol,
-            bids: ob.bids
-                .filter((level): level is [number, number] => level[0] !== undefined && level[1] !== undefined)
-                .map(([price, amount]) => ({ price, amount })),
-            asks: ob.asks
-                .filter((level): level is [number, number] => level[0] !== undefined && level[1] !== undefined)
-                .map(([price, amount]) => ({ price, amount })),
+            bids: normalizeLevels(ob.bids),
+            asks: normalizeLevels(ob.asks),
             exchangeTimestamp: ob.timestamp ?? undefined,
             receivedAt: Date.now(),
             sequence,

--- a/order-router/src/connectors/exchangeConnector.ts
+++ b/order-router/src/connectors/exchangeConnector.ts
@@ -1,12 +1,27 @@
-import ccxt, { Exchange } from 'ccxt';
+import ccxt, { Exchange, type OrderBook } from 'ccxt';
 import type { OrderBookCache } from '../cache/orderBookCache.js';
+import type { FeeRegistry } from '../cache/feeRegistry.js';
 import type { Logger } from 'pino';
 
 const BACKOFF_START_MS = 500;
 const BACKOFF_MAX_MS = 30_000;
+// Spacing between starting individual watch loops (per-symbol loops on exchanges that don't
+// support watchOrderBookForSymbols, or per-chunk batched loops on ones that do) — without this,
+// N loops means N near-simultaneous subscribe messages at startup, which is exactly what
+// triggered exchange-side rate limiting and a reconnect storm when this connector was tested
+// against a 400+-symbol exchange.
+const LOOP_START_STAGGER_MS = 25;
 
 function sleep (ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Full jitter: spreads out retries so N loops that all failed at the same instant (e.g. a shared
+// WS connection dropping, which fails every per-symbol watchOrderBook call on that exchange at
+// once) don't all retry in lockstep and repeat the thundering-herd rate-limit hit every backoff
+// cycle.
+function jittered (ms: number): number {
+    return Math.random() * ms;
 }
 
 // One connector owns exactly one exchange's WS connection(s) and one or more
@@ -16,70 +31,155 @@ export class ExchangeConnector {
     readonly exchangeId: string;
     private exchange: Exchange;
     private cache: OrderBookCache;
+    private feeRegistry: FeeRegistry;
     private logger: Logger;
     private stopped = false;
     private symbols: string[] = [];
+    private maxSymbolsPerSubscription: number;
+    private maxSymbolsForExchange: number | undefined;
 
-    constructor (exchangeId: string, cache: OrderBookCache, logger: Logger) {
+    // `existingExchange` lets a caller that already ran loadMarkets() (e.g. discovery, which
+    // needs markets to compute the routable symbol universe before connectors exist) hand off
+    // that same instance instead of forcing a second loadMarkets() round-trip here. Only
+    // meaningful within a single process — a shard worker always constructs its own.
+    constructor (
+        exchangeId: string,
+        cache: OrderBookCache,
+        feeRegistry: FeeRegistry,
+        logger: Logger,
+        existingExchange?: Exchange,
+        maxSymbolsPerSubscription = 50,
+        maxSymbolsForExchange?: number,
+    ) {
         this.exchangeId = exchangeId;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const ExchangeClass = (ccxt.pro as any)[exchangeId];
-        if (!ExchangeClass) {
-            throw new Error(`ccxt.pro does not support exchange '${exchangeId}'`);
+        this.maxSymbolsPerSubscription = maxSymbolsPerSubscription;
+        this.maxSymbolsForExchange = maxSymbolsForExchange;
+        if (existingExchange) {
+            this.exchange = existingExchange;
+        } else {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ExchangeClass = (ccxt.pro as any)[exchangeId];
+            if (!ExchangeClass) {
+                throw new Error(`ccxt.pro does not support exchange '${exchangeId}'`);
+            }
+            this.exchange = new ExchangeClass({ enableRateLimit: true });
         }
-        this.exchange = new ExchangeClass({ enableRateLimit: true });
         this.cache = cache;
+        this.feeRegistry = feeRegistry;
         this.logger = logger.child({ exchange: exchangeId });
         this.cache.initHealth(exchangeId);
     }
 
-    getTakerFee (symbol: string): number {
-        const market = this.exchange.markets?.[symbol];
-        return market?.taker ?? this.exchange.fees?.trading?.taker ?? 0.001;
-    }
-
     async start (requestedSymbols: string[]): Promise<void> {
-        await this.exchange.loadMarkets();
+        if (!this.exchange.markets) {
+            await this.exchange.loadMarkets();
+        }
         this.symbols = requestedSymbols.filter((s) => {
-            const supported = Boolean(this.exchange.markets?.[s]);
-            if (!supported) {
+            const market = this.exchange.markets?.[s];
+            if (!market) {
                 this.logger.warn({ symbol: s }, 'symbol not supported on this exchange, skipping');
+                return false;
             }
-            return supported;
+            const takerFeeRate = market.taker ?? this.exchange.fees?.trading?.taker ?? 0.001;
+            this.feeRegistry.setFee(this.exchangeId, s, takerFeeRate);
+            return true;
         });
-        for (const symbol of this.symbols) {
-            void this.watchLoop(symbol);
+
+        if (this.maxSymbolsForExchange !== undefined && this.symbols.length > this.maxSymbolsForExchange) {
+            const dropped = this.symbols.length - this.maxSymbolsForExchange;
+            this.logger.warn(
+                { requested: this.symbols.length, cap: this.maxSymbolsForExchange, dropped },
+                'exceeds this exchange\'s configured total-symbol cap (session-wide subscription limit), truncating',
+            );
+            this.symbols = this.symbols.slice(0, this.maxSymbolsForExchange);
+        }
+
+        if (this.symbols.length === 0) return;
+
+        // Prefer batched subscriptions over independent per-symbol ones whenever the exchange
+        // supports it — that's what watchOrderBookForSymbols exists for. But even where
+        // supported, exchanges cap how many symbols one subscription/session can cover (observed
+        // directly: Coinbase "too many L2 streams", Bitget "subscribe over limit, max:1000",
+        // KuCoin rejecting an overlong topic string) — so still chunk into
+        // maxSymbolsPerSubscription-sized groups, each its own independent watch loop, rather
+        // than one unbounded call for every routable symbol on the exchange.
+        if (this.exchange.has?.watchOrderBookForSymbols && this.symbols.length > 1) {
+            const chunks: string[][] = [];
+            for (let i = 0; i < this.symbols.length; i += this.maxSymbolsPerSubscription) {
+                chunks.push(this.symbols.slice(i, i + this.maxSymbolsPerSubscription));
+            }
+            this.logger.info(
+                { symbolCount: this.symbols.length, chunkCount: chunks.length, chunkSize: this.maxSymbolsPerSubscription },
+                'using batched watchOrderBookForSymbols, chunked',
+            );
+            chunks.forEach((chunk, i) => {
+                void sleep(i * LOOP_START_STAGGER_MS).then(() => this.batchWatchLoop(chunk));
+            });
+        } else {
+            this.logger.info(
+                { symbolCount: this.symbols.length },
+                'watchOrderBookForSymbols not supported here, using per-symbol loops (staggered start)',
+            );
+            this.symbols.forEach((symbol, i) => {
+                void sleep(i * LOOP_START_STAGGER_MS).then(() => this.singleSymbolWatchLoop(symbol));
+            });
         }
     }
 
-    private async watchLoop (symbol: string): Promise<void> {
+    private applyOrderBook (symbol: string, ob: OrderBook, sequence: number): void {
+        this.cache.setBook({
+            exchangeId: this.exchangeId,
+            symbol,
+            bids: ob.bids
+                .filter((level): level is [number, number] => level[0] !== undefined && level[1] !== undefined)
+                .map(([price, amount]) => ({ price, amount })),
+            asks: ob.asks
+                .filter((level): level is [number, number] => level[0] !== undefined && level[1] !== undefined)
+                .map(([price, amount]) => ({ price, amount })),
+            exchangeTimestamp: ob.timestamp ?? undefined,
+            receivedAt: Date.now(),
+            sequence,
+        });
+        this.cache.recordUpdate(this.exchangeId);
+    }
+
+    private async batchWatchLoop (symbols: string[]): Promise<void> {
+        let backoff = BACKOFF_START_MS;
+        let sequence = 0;
+        while (!this.stopped) {
+            try {
+                const ob = await this.exchange.watchOrderBookForSymbols(symbols);
+                sequence += 1;
+                if (ob.symbol) {
+                    this.applyOrderBook(ob.symbol, ob, sequence);
+                }
+                backoff = BACKOFF_START_MS;
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                this.logger.error({ err: message }, 'watchOrderBookForSymbols failed, backing off');
+                this.cache.recordError(this.exchangeId, message);
+                this.cache.recordReconnect(this.exchangeId);
+                await sleep(jittered(backoff));
+                backoff = Math.min(backoff * 2, BACKOFF_MAX_MS);
+            }
+        }
+    }
+
+    private async singleSymbolWatchLoop (symbol: string): Promise<void> {
         let backoff = BACKOFF_START_MS;
         let sequence = 0;
         while (!this.stopped) {
             try {
                 const ob = await this.exchange.watchOrderBook(symbol);
                 sequence += 1;
-                this.cache.setBook({
-                    exchangeId: this.exchangeId,
-                    symbol,
-                    bids: ob.bids
-                        .filter(([price, amount]) => price !== undefined && amount !== undefined)
-                        .map(([price, amount]) => ({ price: price as number, amount: amount as number })),
-                    asks: ob.asks
-                        .filter(([price, amount]) => price !== undefined && amount !== undefined)
-                        .map(([price, amount]) => ({ price: price as number, amount: amount as number })),
-                    exchangeTimestamp: ob.timestamp ?? undefined,
-                    receivedAt: Date.now(),
-                    sequence,
-                });
-                this.cache.recordUpdate(this.exchangeId);
+                this.applyOrderBook(symbol, ob, sequence);
                 backoff = BACKOFF_START_MS;
             } catch (err) {
                 const message = err instanceof Error ? err.message : String(err);
                 this.logger.error({ symbol, err: message }, 'watchOrderBook failed, backing off');
                 this.cache.recordError(this.exchangeId, message);
                 this.cache.recordReconnect(this.exchangeId);
-                await sleep(backoff);
+                await sleep(jittered(backoff));
                 backoff = Math.min(backoff * 2, BACKOFF_MAX_MS);
             }
         }

--- a/order-router/src/connectors/exchangeConnector.ts
+++ b/order-router/src/connectors/exchangeConnector.ts
@@ -1,0 +1,92 @@
+import ccxt, { Exchange } from 'ccxt';
+import type { OrderBookCache } from '../cache/orderBookCache.js';
+import type { Logger } from 'pino';
+
+const BACKOFF_START_MS = 500;
+const BACKOFF_MAX_MS = 30_000;
+
+function sleep (ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// One connector owns exactly one exchange's WS connection(s) and one or more
+// symbol watch loops. A crash/error in one connector never touches another —
+// each catches its own errors and reconnects with backoff independently.
+export class ExchangeConnector {
+    readonly exchangeId: string;
+    private exchange: Exchange;
+    private cache: OrderBookCache;
+    private logger: Logger;
+    private stopped = false;
+    private symbols: string[] = [];
+
+    constructor (exchangeId: string, cache: OrderBookCache, logger: Logger) {
+        this.exchangeId = exchangeId;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const ExchangeClass = (ccxt.pro as any)[exchangeId];
+        if (!ExchangeClass) {
+            throw new Error(`ccxt.pro does not support exchange '${exchangeId}'`);
+        }
+        this.exchange = new ExchangeClass({ enableRateLimit: true });
+        this.cache = cache;
+        this.logger = logger.child({ exchange: exchangeId });
+        this.cache.initHealth(exchangeId);
+    }
+
+    getTakerFee (symbol: string): number {
+        const market = this.exchange.markets?.[symbol];
+        return market?.taker ?? this.exchange.fees?.trading?.taker ?? 0.001;
+    }
+
+    async start (requestedSymbols: string[]): Promise<void> {
+        await this.exchange.loadMarkets();
+        this.symbols = requestedSymbols.filter((s) => {
+            const supported = Boolean(this.exchange.markets?.[s]);
+            if (!supported) {
+                this.logger.warn({ symbol: s }, 'symbol not supported on this exchange, skipping');
+            }
+            return supported;
+        });
+        for (const symbol of this.symbols) {
+            void this.watchLoop(symbol);
+        }
+    }
+
+    private async watchLoop (symbol: string): Promise<void> {
+        let backoff = BACKOFF_START_MS;
+        let sequence = 0;
+        while (!this.stopped) {
+            try {
+                const ob = await this.exchange.watchOrderBook(symbol);
+                sequence += 1;
+                this.cache.setBook({
+                    exchangeId: this.exchangeId,
+                    symbol,
+                    bids: ob.bids
+                        .filter(([price, amount]) => price !== undefined && amount !== undefined)
+                        .map(([price, amount]) => ({ price: price as number, amount: amount as number })),
+                    asks: ob.asks
+                        .filter(([price, amount]) => price !== undefined && amount !== undefined)
+                        .map(([price, amount]) => ({ price: price as number, amount: amount as number })),
+                    exchangeTimestamp: ob.timestamp ?? undefined,
+                    receivedAt: Date.now(),
+                    sequence,
+                });
+                this.cache.recordUpdate(this.exchangeId);
+                backoff = BACKOFF_START_MS;
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                this.logger.error({ symbol, err: message }, 'watchOrderBook failed, backing off');
+                this.cache.recordError(this.exchangeId, message);
+                this.cache.recordReconnect(this.exchangeId);
+                await sleep(backoff);
+                backoff = Math.min(backoff * 2, BACKOFF_MAX_MS);
+            }
+        }
+    }
+
+    async stop (): Promise<void> {
+        this.stopped = true;
+        await this.exchange.close();
+    }
+}

--- a/order-router/src/discovery/exchangeDiscovery.ts
+++ b/order-router/src/discovery/exchangeDiscovery.ts
@@ -1,0 +1,23 @@
+import ccxt from 'ccxt';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ccxtPro = ccxt.pro as any;
+
+// Every ccxt.pro exchange id whose class actually implements watchOrderBook.
+// This is a local, network-free check (`has` is a static describe()-derived
+// property on a freshly constructed instance) — safe to run unconditionally.
+export function listWatchOrderBookExchanges (exclude: Set<string>): string[] {
+    const ids: string[] = [];
+    for (const id of Object.keys(ccxtPro)) {
+        if (typeof ccxtPro[id] !== 'function' || exclude.has(id)) continue;
+        try {
+            const instance = new ccxtPro[id]();
+            if (instance.has?.watchOrderBook) {
+                ids.push(id);
+            }
+        } catch {
+            // Some exported keys aren't exchange classes (e.g. helper namespaces); skip silently.
+        }
+    }
+    return ids;
+}

--- a/order-router/src/discovery/symbolUniverse.test.ts
+++ b/order-router/src/discovery/symbolUniverse.test.ts
@@ -1,0 +1,47 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeRoutableSymbols } from './symbolUniverse.js';
+
+test('a symbol on exactly one exchange is excluded from the routable set', () => {
+    const markets = new Map([
+        ['kraken', ['BTC/USDT', 'ONLY_ON_KRAKEN/USDT']],
+        ['coinbase', ['BTC/USDT']],
+    ]);
+
+    const result = computeRoutableSymbols(markets, 2);
+
+    assert.deepEqual(result.routableSymbolsByExchange.get('kraken'), ['BTC/USDT']);
+    assert.deepEqual(result.routableSymbolsByExchange.get('coinbase'), ['BTC/USDT']);
+    assert.equal(result.totalUniqueSymbols, 2);
+    assert.equal(result.routableSymbolCount, 1);
+});
+
+test('an exchange with zero routable symbols is absent from the result map', () => {
+    const markets = new Map([
+        ['kraken', ['BTC/USDT']],
+        ['coinbase', ['BTC/USDT']],
+        ['lonely', ['NOBODY_ELSE_HAS/USDT']],
+    ]);
+
+    const result = computeRoutableSymbols(markets, 2);
+
+    assert.equal(result.routableSymbolsByExchange.has('lonely'), false);
+});
+
+test('minExchangesPerSymbol threshold is inclusive', () => {
+    const markets = new Map([
+        ['a', ['X/USDT']],
+        ['b', ['X/USDT']],
+        ['c', ['X/USDT']],
+    ]);
+
+    assert.equal(computeRoutableSymbols(markets, 3).routableSymbolCount, 1);
+    assert.equal(computeRoutableSymbols(markets, 4).routableSymbolCount, 0);
+});
+
+test('empty input produces empty output, not an error', () => {
+    const result = computeRoutableSymbols(new Map(), 2);
+    assert.equal(result.totalUniqueSymbols, 0);
+    assert.equal(result.routableSymbolCount, 0);
+    assert.equal(result.routableSymbolsByExchange.size, 0);
+});

--- a/order-router/src/discovery/symbolUniverse.ts
+++ b/order-router/src/discovery/symbolUniverse.ts
@@ -1,0 +1,102 @@
+import ccxt, { Exchange } from 'ccxt';
+import type { Logger } from 'pino';
+
+export interface SymbolUniverse {
+    // Only symbols tradable on >= minExchangesPerSymbol exchanges — the routable set.
+    routableSymbolsByExchange: Map<string, string[]>;
+    // Already-instantiated, already-loadMarkets()'d ccxt.pro instances, keyed by exchange id —
+    // handed off to ExchangeConnector so it doesn't need a second loadMarkets() round trip.
+    loadedExchanges: Map<string, Exchange>;
+    exchangesFailed: Map<string, string>;
+    totalUniqueSymbols: number;
+    routableSymbolCount: number;
+}
+
+async function runWithConcurrency<T, R> (
+    items: T[],
+    limit: number,
+    worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+    const results: R[] = new Array(items.length);
+    let next = 0;
+    async function runner (): Promise<void> {
+        while (next < items.length) {
+            const idx = next++;
+            results[idx] = await worker(items[idx] as T);
+        }
+    }
+    await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => runner()));
+    return results;
+}
+
+// Loads markets for every candidate exchange (bounded concurrency, tolerant of individual
+// failures — one geo-blocked/rate-limited exchange doesn't abort discovery for the rest), then
+// keeps only symbols that appear on >= minExchangesPerSymbol exchanges. A symbol on exactly one
+// exchange has nothing to route between, so it's excluded from the routable set even though its
+// exchange stays in loadedExchanges (it just won't get any watch loops started for it).
+export async function buildSymbolUniverse (
+    exchangeIds: string[],
+    minExchangesPerSymbol: number,
+    concurrency: number,
+    logger: Logger,
+): Promise<SymbolUniverse> {
+    const loadedExchanges = new Map<string, Exchange>();
+    const marketsByExchange = new Map<string, string[]>();
+    const exchangesFailed = new Map<string, string>();
+
+    await runWithConcurrency(exchangeIds, concurrency, async (id) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const ExchangeClass = (ccxt.pro as any)[id];
+        if (!ExchangeClass) {
+            exchangesFailed.set(id, 'no ccxt.pro class for this id');
+            return;
+        }
+        const exchange: Exchange = new ExchangeClass({ enableRateLimit: true });
+        try {
+            await exchange.loadMarkets();
+            const symbols = Object.keys(exchange.markets ?? {});
+            marketsByExchange.set(id, symbols);
+            loadedExchanges.set(id, exchange);
+            logger.info({ exchange: id, marketCount: symbols.length }, 'loaded markets');
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            exchangesFailed.set(id, message);
+            logger.warn({ exchange: id, err: message }, 'loadMarkets failed during discovery, skipping');
+        }
+    });
+
+    const exchangesBySymbol = new Map<string, Set<string>>();
+    for (const [exchangeId, symbols] of marketsByExchange) {
+        for (const symbol of symbols) {
+            let set = exchangesBySymbol.get(symbol);
+            if (!set) {
+                set = new Set();
+                exchangesBySymbol.set(symbol, set);
+            }
+            set.add(exchangeId);
+        }
+    }
+
+    const routableSymbols = new Set<string>();
+    for (const [symbol, exchangeSet] of exchangesBySymbol) {
+        if (exchangeSet.size >= minExchangesPerSymbol) {
+            routableSymbols.add(symbol);
+        }
+    }
+
+    const routableSymbolsByExchange = new Map<string, string[]>();
+    for (const [exchangeId, symbols] of marketsByExchange) {
+        const routable = symbols.filter((s) => routableSymbols.has(s));
+        if (routable.length > 0) {
+            routableSymbolsByExchange.set(exchangeId, routable);
+        }
+    }
+
+    return {
+        routableSymbolsByExchange,
+        loadedExchanges,
+        exchangesFailed,
+        totalUniqueSymbols: exchangesBySymbol.size,
+        routableSymbolCount: routableSymbols.size,
+    };
+}

--- a/order-router/src/discovery/symbolUniverse.ts
+++ b/order-router/src/discovery/symbolUniverse.ts
@@ -12,6 +12,12 @@ export interface SymbolUniverse {
     routableSymbolCount: number;
 }
 
+export interface RoutableSymbols {
+    routableSymbolsByExchange: Map<string, string[]>;
+    totalUniqueSymbols: number;
+    routableSymbolCount: number;
+}
+
 async function runWithConcurrency<T, R> (
     items: T[],
     limit: number,
@@ -29,11 +35,53 @@ async function runWithConcurrency<T, R> (
     return results;
 }
 
+// Pure: given each exchange's already-loaded market symbol list, keeps only symbols that appear
+// on >= minExchangesPerSymbol exchanges. A symbol on exactly one exchange has nothing to route
+// between, so it's excluded from the routable set (though its exchange can still appear in the
+// input — it just won't get any watch loops started for it). Split out from buildSymbolUniverse
+// so this logic — the actual "what's worth subscribing to" decision — is unit-testable without a
+// network call.
+export function computeRoutableSymbols (
+    marketsByExchange: Map<string, string[]>,
+    minExchangesPerSymbol: number,
+): RoutableSymbols {
+    const exchangesBySymbol = new Map<string, Set<string>>();
+    for (const [exchangeId, symbols] of marketsByExchange) {
+        for (const symbol of symbols) {
+            let set = exchangesBySymbol.get(symbol);
+            if (!set) {
+                set = new Set();
+                exchangesBySymbol.set(symbol, set);
+            }
+            set.add(exchangeId);
+        }
+    }
+
+    const routableSymbols = new Set<string>();
+    for (const [symbol, exchangeSet] of exchangesBySymbol) {
+        if (exchangeSet.size >= minExchangesPerSymbol) {
+            routableSymbols.add(symbol);
+        }
+    }
+
+    const routableSymbolsByExchange = new Map<string, string[]>();
+    for (const [exchangeId, symbols] of marketsByExchange) {
+        const routable = symbols.filter((s) => routableSymbols.has(s));
+        if (routable.length > 0) {
+            routableSymbolsByExchange.set(exchangeId, routable);
+        }
+    }
+
+    return {
+        routableSymbolsByExchange,
+        totalUniqueSymbols: exchangesBySymbol.size,
+        routableSymbolCount: routableSymbols.size,
+    };
+}
+
 // Loads markets for every candidate exchange (bounded concurrency, tolerant of individual
 // failures — one geo-blocked/rate-limited exchange doesn't abort discovery for the rest), then
-// keeps only symbols that appear on >= minExchangesPerSymbol exchanges. A symbol on exactly one
-// exchange has nothing to route between, so it's excluded from the routable set even though its
-// exchange stays in loadedExchanges (it just won't get any watch loops started for it).
+// delegates to computeRoutableSymbols for the actual filtering decision.
 export async function buildSymbolUniverse (
     exchangeIds: string[],
     minExchangesPerSymbol: number,
@@ -65,38 +113,11 @@ export async function buildSymbolUniverse (
         }
     });
 
-    const exchangesBySymbol = new Map<string, Set<string>>();
-    for (const [exchangeId, symbols] of marketsByExchange) {
-        for (const symbol of symbols) {
-            let set = exchangesBySymbol.get(symbol);
-            if (!set) {
-                set = new Set();
-                exchangesBySymbol.set(symbol, set);
-            }
-            set.add(exchangeId);
-        }
-    }
-
-    const routableSymbols = new Set<string>();
-    for (const [symbol, exchangeSet] of exchangesBySymbol) {
-        if (exchangeSet.size >= minExchangesPerSymbol) {
-            routableSymbols.add(symbol);
-        }
-    }
-
-    const routableSymbolsByExchange = new Map<string, string[]>();
-    for (const [exchangeId, symbols] of marketsByExchange) {
-        const routable = symbols.filter((s) => routableSymbols.has(s));
-        if (routable.length > 0) {
-            routableSymbolsByExchange.set(exchangeId, routable);
-        }
-    }
+    const routable = computeRoutableSymbols(marketsByExchange, minExchangesPerSymbol);
 
     return {
-        routableSymbolsByExchange,
+        ...routable,
         loadedExchanges,
         exchangesFailed,
-        totalUniqueSymbols: exchangesBySymbol.size,
-        routableSymbolCount: routableSymbols.size,
     };
 }

--- a/order-router/src/index.ts
+++ b/order-router/src/index.ts
@@ -1,37 +1,128 @@
+import type { ChildProcess } from 'node:child_process';
+import type { Exchange } from 'ccxt';
 import { config } from './config.js';
 import { logger } from './logger.js';
 import { OrderBookCache } from './cache/orderBookCache.js';
+import { FeeRegistry } from './cache/feeRegistry.js';
 import { ExchangeConnector } from './connectors/exchangeConnector.js';
 import { buildServer } from './api/server.js';
+import { listWatchOrderBookExchanges } from './discovery/exchangeDiscovery.js';
+import { buildSymbolUniverse } from './discovery/symbolUniverse.js';
+import { partitionAssignments, startShards } from './sharding/orchestrator.js';
+import type { ShardAssignment } from './sharding/messages.js';
 
-async function main () {
-    const cache = new OrderBookCache();
-    const connectors = new Map<string, ExchangeConnector>();
-
-    for (const exchangeId of config.exchanges) {
-        const connector = new ExchangeConnector(exchangeId, cache, logger);
-        connectors.set(exchangeId, connector);
-    }
-
+async function startConnectors (
+    assignments: ShardAssignment[],
+    cache: OrderBookCache,
+    feeRegistry: FeeRegistry,
+    existingExchanges: Map<string, Exchange>,
+): Promise<ExchangeConnector[]> {
+    const connectors = assignments.map(
+        ({ exchangeId }) => new ExchangeConnector(
+            exchangeId,
+            cache,
+            feeRegistry,
+            logger,
+            existingExchanges.get(exchangeId),
+            config.maxSymbolsPerSubscription,
+            config.maxSymbolsPerExchangeOverrides.get(exchangeId),
+        ),
+    );
     await Promise.all(
-        Array.from(connectors.values()).map(async (connector) => {
+        assignments.map(async ({ exchangeId, symbols }, i) => {
             try {
-                await connector.start(config.symbols);
-                logger.info({ exchange: connector.exchangeId }, 'connector started');
+                await connectors[i]!.start(symbols);
+                logger.info({ exchange: exchangeId, symbolCount: symbols.length }, 'connector started');
             } catch (err) {
-                logger.error({ exchange: connector.exchangeId, err }, 'connector failed to start');
+                logger.error({ exchange: exchangeId, err }, 'connector failed to start');
             }
         }),
     );
+    return connectors;
+}
 
-    const app = await buildServer(cache, connectors, logger);
+async function main () {
+    const cache = new OrderBookCache();
+    const feeRegistry = new FeeRegistry();
+    const excludeSet = new Set(config.excludeExchanges);
+
+    let assignments: ShardAssignment[];
+    let existingExchanges = new Map<string, Exchange>();
+
+    if (config.discoverAllExchanges) {
+        const candidateIds = listWatchOrderBookExchanges(excludeSet);
+        logger.info({ count: candidateIds.length }, 'discovered ccxt.pro exchanges with watchOrderBook support');
+
+        const universe = await buildSymbolUniverse(
+            candidateIds,
+            config.minExchangesPerSymbol,
+            config.loadMarketsConcurrency,
+            logger,
+        );
+
+        for (const [exchangeId, message] of universe.exchangesFailed) {
+            logger.warn({ exchange: exchangeId, err: message }, 'excluded from discovery: loadMarkets failed');
+        }
+        logger.info(
+            {
+                exchangesLoaded: universe.loadedExchanges.size,
+                exchangesFailed: universe.exchangesFailed.size,
+                totalUniqueSymbols: universe.totalUniqueSymbols,
+                routableSymbolCount: universe.routableSymbolCount,
+                minExchangesPerSymbol: config.minExchangesPerSymbol,
+            },
+            'symbol universe built',
+        );
+
+        assignments = Array.from(universe.routableSymbolsByExchange.entries()).map(([exchangeId, symbols]) => ({
+            exchangeId,
+            symbols,
+        }));
+
+        if (assignments.length === 0) {
+            logger.error('no exchanges have any routable symbols (>= minExchangesPerSymbol) — nothing to do');
+        }
+
+        // Discovery instances only exist to compute the symbol universe. In single-process mode
+        // we hand the already-loaded exchange off to its connector directly (saves a second
+        // loadMarkets round trip); everything else (no routable symbols, or we're sharding and
+        // workers build their own instances) gets closed so we don't leak an unused ccxt.pro
+        // instance's sockets/handles.
+        if (config.shardCount <= 1) {
+            existingExchanges = universe.loadedExchanges;
+        }
+        const keepForReuse = new Set(config.shardCount <= 1 ? assignments.map((a) => a.exchangeId) : []);
+        await Promise.all(
+            Array.from(universe.loadedExchanges.entries())
+                .filter(([exchangeId]) => !keepForReuse.has(exchangeId))
+                .map(([, exchange]) => exchange.close()),
+        );
+    } else {
+        // Explicit exchange/symbol list — the conservative default for local dev (see config.ts).
+        assignments = config.exchanges
+            .filter((id) => !excludeSet.has(id))
+            .map((exchangeId) => ({ exchangeId, symbols: config.symbols }));
+    }
+
+    let connectors: ExchangeConnector[] = [];
+    let shardChildren: ChildProcess[] = [];
+
+    if (config.shardCount > 1) {
+        const groups = partitionAssignments(assignments, config.shardCount);
+        shardChildren = startShards(groups, cache, feeRegistry, logger);
+    } else {
+        connectors = await startConnectors(assignments, cache, feeRegistry, existingExchanges);
+    }
+
+    const app = await buildServer(cache, feeRegistry, logger);
     await app.listen({ port: config.port, host: config.host });
     logger.info({ port: config.port }, 'order-router listening');
 
     const shutdown = async (signal: string) => {
         logger.info({ signal }, 'shutting down');
         await app.close();
-        await Promise.all(Array.from(connectors.values()).map((c) => c.stop()));
+        await Promise.all(connectors.map((c) => c.stop()));
+        shardChildren.forEach((c) => c.disconnect());
         process.exit(0);
     };
     process.on('SIGTERM', () => void shutdown('SIGTERM'));

--- a/order-router/src/index.ts
+++ b/order-router/src/index.ts
@@ -1,0 +1,44 @@
+import { config } from './config.js';
+import { logger } from './logger.js';
+import { OrderBookCache } from './cache/orderBookCache.js';
+import { ExchangeConnector } from './connectors/exchangeConnector.js';
+import { buildServer } from './api/server.js';
+
+async function main () {
+    const cache = new OrderBookCache();
+    const connectors = new Map<string, ExchangeConnector>();
+
+    for (const exchangeId of config.exchanges) {
+        const connector = new ExchangeConnector(exchangeId, cache, logger);
+        connectors.set(exchangeId, connector);
+    }
+
+    await Promise.all(
+        Array.from(connectors.values()).map(async (connector) => {
+            try {
+                await connector.start(config.symbols);
+                logger.info({ exchange: connector.exchangeId }, 'connector started');
+            } catch (err) {
+                logger.error({ exchange: connector.exchangeId, err }, 'connector failed to start');
+            }
+        }),
+    );
+
+    const app = await buildServer(cache, connectors, logger);
+    await app.listen({ port: config.port, host: config.host });
+    logger.info({ port: config.port }, 'order-router listening');
+
+    const shutdown = async (signal: string) => {
+        logger.info({ signal }, 'shutting down');
+        await app.close();
+        await Promise.all(Array.from(connectors.values()).map((c) => c.stop()));
+        process.exit(0);
+    };
+    process.on('SIGTERM', () => void shutdown('SIGTERM'));
+    process.on('SIGINT', () => void shutdown('SIGINT'));
+}
+
+main().catch((err) => {
+    logger.error({ err }, 'fatal startup error');
+    process.exit(1);
+});

--- a/order-router/src/logger.ts
+++ b/order-router/src/logger.ts
@@ -1,0 +1,7 @@
+import pino from 'pino';
+import { config } from './config.js';
+
+export const logger = pino({
+    level: config.logLevel,
+    transport: process.env['NODE_ENV'] === 'production' ? undefined : { target: 'pino-pretty' },
+});

--- a/order-router/src/mcp/server.test.ts
+++ b/order-router/src/mcp/server.test.ts
@@ -1,0 +1,107 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer, type Server } from 'node:http';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { buildMcpServer } from './server.js';
+
+// Real end-to-end MCP protocol test: a real Client talking to a real McpServer over a linked
+// in-memory transport pair (the SDK's own test fixture for exactly this), with the server's
+// tools pointed at a tiny real HTTP fixture standing in for the order-router API. No mocking of
+// the MCP protocol itself — this exercises tool registration, JSON-RPC call/response, and the
+// HTTP proxy layer together.
+async function withRouterFixture (
+    responses: Record<string, unknown>,
+    run: (baseUrl: string) => Promise<void>,
+): Promise<void> {
+    const server: Server = createServer((req, res) => {
+        const body = responses[req.url ?? ''];
+        if (body === undefined) {
+            res.writeHead(404, { 'content-type': 'application/json' }).end(JSON.stringify({ error: 'not found' }));
+            return;
+        }
+        res.writeHead(200, { 'content-type': 'application/json' }).end(JSON.stringify(body));
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+    try {
+        await run(`http://127.0.0.1:${port}`);
+    } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+}
+
+async function connectedClient (baseUrl: string): Promise<Client> {
+    const mcpServer = buildMcpServer({ baseUrl });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
+    return client;
+}
+
+test('lists all five router tools', async () => {
+    await withRouterFixture({}, async (baseUrl) => {
+        const client = await connectedClient(baseUrl);
+        const { tools } = await client.listTools();
+        const names = tools.map((t) => t.name).sort();
+        assert.deepEqual(names, [
+            'get_best_price',
+            'get_exchanges_status',
+            'get_health',
+            'get_order_book',
+            'list_symbols',
+        ]);
+        await client.close();
+    });
+});
+
+test('get_health tool call returns the fixture health payload', async () => {
+    await withRouterFixture({ '/health': { status: 'ok', uptimeSec: 42 } }, async (baseUrl) => {
+        const client = await connectedClient(baseUrl);
+        const result = await client.callTool({ name: 'get_health', arguments: {} });
+        const text = (result.content as { type: string; text: string }[])[0]?.text ?? '';
+        assert.deepEqual(JSON.parse(text), { status: 'ok', uptimeSec: 42 });
+        await client.close();
+    });
+});
+
+test('get_best_price tool call passes arguments through to the correct URL', async () => {
+    await withRouterFixture(
+        { '/price/best/BTC%2FUSDT?side=buy&amount=1': { symbol: 'BTC/USDT', best: { exchangeId: 'kraken' } } },
+        async (baseUrl) => {
+            const client = await connectedClient(baseUrl);
+            const result = await client.callTool({
+                name: 'get_best_price',
+                arguments: { symbol: 'BTC/USDT', side: 'buy', amount: 1 },
+            });
+            const text = (result.content as { type: string; text: string }[])[0]?.text ?? '';
+            assert.equal(JSON.parse(text).best.exchangeId, 'kraken');
+            await client.close();
+        },
+    );
+});
+
+test('a failed upstream call surfaces as an MCP tool error, not a protocol failure', async () => {
+    await withRouterFixture({}, async (baseUrl) => {
+        const client = await connectedClient(baseUrl);
+        const result = await client.callTool({
+            name: 'get_order_book',
+            arguments: { exchange: 'kraken', symbol: 'BTC/USDT' },
+        });
+        assert.equal(result.isError, true);
+        await client.close();
+    });
+});
+
+test('get_best_price returns an MCP tool error for an invalid side, via the input schema', async () => {
+    await withRouterFixture({}, async (baseUrl) => {
+        const client = await connectedClient(baseUrl);
+        const result = await client.callTool({
+            name: 'get_best_price',
+            arguments: { symbol: 'BTC/USDT', side: 'sideways', amount: 1 },
+        });
+        assert.equal(result.isError, true);
+        await client.close();
+    });
+});

--- a/order-router/src/mcp/server.ts
+++ b/order-router/src/mcp/server.ts
@@ -1,0 +1,152 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { z } from 'zod';
+import { logger } from '../logger.js';
+import * as routerClient from './tools.js';
+import type { RouterClientOptions } from './tools.js';
+
+const API_BASE_URL = process.env['ORDER_ROUTER_API_URL'] ?? 'http://localhost:8080';
+const MCP_PORT = Number(process.env['ORDER_ROUTER_MCP_PORT'] ?? 8081);
+const MCP_HOST = process.env['ORDER_ROUTER_MCP_HOST'] ?? '0.0.0.0';
+
+function textResult (data: unknown) {
+    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+function errorResult (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: 'text' as const, text: message }], isError: true };
+}
+
+// A fresh McpServer per request, matching the SDK's documented stateless pattern — this is a
+// read-only proxy over public endpoints, so there's no session state worth keeping across
+// requests, and stateless mode avoids needing session-id bookkeeping entirely.
+export function buildMcpServer (clientOptions: RouterClientOptions): McpServer {
+    const server = new McpServer({ name: 'order-router-mcp', version: '0.1.0' });
+
+    server.registerTool(
+        'get_health',
+        { title: 'Router health', description: 'Liveness check for the order-router service.' },
+        async () => {
+            try {
+                return textResult(await routerClient.getHealth(clientOptions));
+            } catch (err) {
+                return errorResult(err);
+            }
+        },
+    );
+
+    server.registerTool(
+        'get_exchanges_status',
+        {
+            title: 'Exchange connection status',
+            description: 'Per-exchange WS health: connected, last update age, update/reconnect counts.',
+        },
+        async () => {
+            try {
+                return textResult(await routerClient.getExchangesStatus(clientOptions));
+            } catch (err) {
+                return errorResult(err);
+            }
+        },
+    );
+
+    server.registerTool(
+        'list_symbols',
+        { title: 'List cached symbols', description: 'Unified symbols currently cached by the router.' },
+        async () => {
+            try {
+                return textResult(await routerClient.listSymbols(clientOptions));
+            } catch (err) {
+                return errorResult(err);
+            }
+        },
+    );
+
+    server.registerTool(
+        'get_order_book',
+        {
+            title: 'Get order book',
+            description: 'Cached L2 order book snapshot for one exchange and symbol.',
+            inputSchema: {
+                exchange: z.string().describe('ccxt exchange id, e.g. "kraken"'),
+                symbol: z.string().describe('Unified symbol, e.g. "BTC/USDT"'),
+            },
+        },
+        async ({ exchange, symbol }) => {
+            try {
+                return textResult(await routerClient.getOrderBook(exchange, symbol, clientOptions));
+            } catch (err) {
+                return errorResult(err);
+            }
+        },
+    );
+
+    server.registerTool(
+        'get_best_price',
+        {
+            title: 'Get best execution price',
+            description: 'Book-walked, fee-adjusted best execution price across exchanges for a given order size.',
+            inputSchema: {
+                symbol: z.string().describe('Unified symbol, e.g. "BTC/USDT"'),
+                side: z.enum(['buy', 'sell']).describe('Order side'),
+                amount: z.number().positive().describe('Order size in base currency units'),
+            },
+        },
+        async ({ symbol, side, amount }) => {
+            try {
+                return textResult(await routerClient.getBestPrice(symbol, side, amount, clientOptions));
+            } catch (err) {
+                return errorResult(err);
+            }
+        },
+    );
+
+    return server;
+}
+
+async function handleMcpRequest (req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const server = buildMcpServer({ baseUrl: API_BASE_URL });
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    res.on('close', () => {
+        void transport.close();
+        void server.close();
+    });
+    await server.connect(transport);
+    await transport.handleRequest(req, res);
+}
+
+async function main (): Promise<void> {
+    const httpServer = createServer((req, res) => {
+        if (req.url === '/mcp' && req.method === 'POST') {
+            void handleMcpRequest(req, res).catch((err) => {
+                logger.error({ err }, 'MCP request handling failed');
+                if (!res.headersSent) {
+                    res.writeHead(500, { 'content-type': 'application/json' }).end(
+                        JSON.stringify({ jsonrpc: '2.0', error: { code: -32603, message: 'internal error' }, id: null }),
+                    );
+                }
+            });
+            return;
+        }
+        if (req.url === '/health' && req.method === 'GET') {
+            res.writeHead(200, { 'content-type': 'application/json' }).end(JSON.stringify({ status: 'ok' }));
+            return;
+        }
+        res.writeHead(404).end();
+    });
+
+    httpServer.listen(MCP_PORT, MCP_HOST, () => {
+        logger.info({ port: MCP_PORT, apiBaseUrl: API_BASE_URL }, 'order-router MCP server listening');
+    });
+}
+
+// Only auto-start when run directly (`node dist/mcp/server.js`) — importing buildMcpServer for
+// tests should never open a port as a side effect.
+if (import.meta.url === `file://${process.argv[1]}`) {
+    main().catch((err) => {
+        logger.error({ err }, 'fatal MCP server startup error');
+        process.exit(1);
+    });
+}

--- a/order-router/src/mcp/server.ts
+++ b/order-router/src/mcp/server.ts
@@ -4,12 +4,15 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { z } from 'zod';
 import { logger } from '../logger.js';
 import { extractApiKey, resolveApiKey, safeCompare } from '../api/auth.js';
+import { FixedWindowRateLimiter } from '../api/rateLimiter.js';
 import * as routerClient from './tools.js';
 import type { RouterClientOptions } from './tools.js';
 
 const API_BASE_URL = process.env['ORDER_ROUTER_API_URL'] ?? 'http://localhost:8080';
 const MCP_PORT = Number(process.env['ORDER_ROUTER_MCP_PORT'] ?? 8081);
 const MCP_HOST = process.env['ORDER_ROUTER_MCP_HOST'] ?? '0.0.0.0';
+const MCP_RATE_LIMIT_MAX = Number(process.env['ORDER_ROUTER_RATE_LIMIT_MAX'] ?? 600);
+const MCP_RATE_LIMIT_WINDOW_MS = Number(process.env['ORDER_ROUTER_RATE_LIMIT_WINDOW_MS'] ?? 60_000);
 
 function textResult (data: unknown) {
     return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
@@ -127,13 +130,35 @@ async function main (): Promise<void> {
         );
     }
 
+    const limiter = new FixedWindowRateLimiter(MCP_RATE_LIMIT_MAX, MCP_RATE_LIMIT_WINDOW_MS);
+
     const httpServer = createServer((req, res) => {
         if (req.url === '/mcp' && req.method === 'POST') {
             // The MCP endpoint proxies privileged router data, so it authenticates its own callers
             // with the same key it uses upstream — otherwise it would be an open bypass around the
             // router's auth.
             const provided = extractApiKey(req.headers as Record<string, unknown>);
-            if (provided === undefined || !safeCompare(provided, apiKey)) {
+            const keyIsValid = provided !== undefined && safeCompare(provided, apiKey);
+
+            // Rate limit BEFORE returning the auth verdict, and bucket by key only when the key is
+            // valid. Without this the MCP port is a second, equivalent brute-force door: the
+            // router's limiter lives in a different process on a different port and does not cover
+            // it, so unlimited key guessing here would defeat the fix applied there.
+            const bucketKey = keyIsValid ? (provided as string) : (req.socket.remoteAddress ?? 'unknown');
+            const decision = limiter.consume(bucketKey);
+            if (!decision.allowed) {
+                res.writeHead(429, {
+                    'content-type': 'application/json',
+                    'retry-after': String(decision.resetSeconds),
+                    'x-ratelimit-limit': String(decision.limit),
+                    'x-ratelimit-remaining': String(decision.remaining),
+                }).end(
+                    JSON.stringify({ jsonrpc: '2.0', error: { code: -32002, message: 'rate limit exceeded' }, id: null }),
+                );
+                return;
+            }
+
+            if (!keyIsValid) {
                 res.writeHead(401, { 'content-type': 'application/json' }).end(
                     JSON.stringify({ jsonrpc: '2.0', error: { code: -32001, message: 'unauthorized' }, id: null }),
                 );

--- a/order-router/src/mcp/server.ts
+++ b/order-router/src/mcp/server.ts
@@ -3,6 +3,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { z } from 'zod';
 import { logger } from '../logger.js';
+import { extractApiKey, resolveApiKey, safeCompare } from '../api/auth.js';
 import * as routerClient from './tools.js';
 import type { RouterClientOptions } from './tools.js';
 
@@ -106,8 +107,8 @@ export function buildMcpServer (clientOptions: RouterClientOptions): McpServer {
     return server;
 }
 
-async function handleMcpRequest (req: IncomingMessage, res: ServerResponse): Promise<void> {
-    const server = buildMcpServer({ baseUrl: API_BASE_URL });
+async function handleMcpRequest (req: IncomingMessage, res: ServerResponse, apiKey: string): Promise<void> {
+    const server = buildMcpServer({ baseUrl: API_BASE_URL, apiKey });
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
     res.on('close', () => {
         void transport.close();
@@ -118,9 +119,27 @@ async function handleMcpRequest (req: IncomingMessage, res: ServerResponse): Pro
 }
 
 async function main (): Promise<void> {
+    const { apiKey, isDefault } = resolveApiKey();
+    if (isDefault) {
+        logger.warn(
+            'ORDER_ROUTER_API_KEY is not set — MCP server is using the well-known development key '
+            + 'for both inbound auth and upstream calls. Set ORDER_ROUTER_API_KEY before exposing it.',
+        );
+    }
+
     const httpServer = createServer((req, res) => {
         if (req.url === '/mcp' && req.method === 'POST') {
-            void handleMcpRequest(req, res).catch((err) => {
+            // The MCP endpoint proxies privileged router data, so it authenticates its own callers
+            // with the same key it uses upstream — otherwise it would be an open bypass around the
+            // router's auth.
+            const provided = extractApiKey(req.headers as Record<string, unknown>);
+            if (provided === undefined || !safeCompare(provided, apiKey)) {
+                res.writeHead(401, { 'content-type': 'application/json' }).end(
+                    JSON.stringify({ jsonrpc: '2.0', error: { code: -32001, message: 'unauthorized' }, id: null }),
+                );
+                return;
+            }
+            void handleMcpRequest(req, res, apiKey).catch((err) => {
                 logger.error({ err }, 'MCP request handling failed');
                 if (!res.headersSent) {
                     res.writeHead(500, { 'content-type': 'application/json' }).end(

--- a/order-router/src/mcp/tools.test.ts
+++ b/order-router/src/mcp/tools.test.ts
@@ -1,0 +1,89 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer, type Server } from 'node:http';
+import * as routerClient from './tools.js';
+
+// A tiny real HTTP fixture standing in for the order-router's own API, rather than mocking
+// fetch — exercises the actual request/response path (URL construction, JSON parsing, error
+// handling on non-2xx) the way the MCP server will really use it.
+async function withFixture (
+    handler: (path: string) => { status: number; body: unknown },
+    run: (baseUrl: string) => Promise<void>,
+): Promise<void> {
+    const server: Server = createServer((req, res) => {
+        const { status, body } = handler(req.url ?? '/');
+        res.writeHead(status, { 'content-type': 'application/json' }).end(JSON.stringify(body));
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+    try {
+        await run(`http://127.0.0.1:${port}`);
+    } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+}
+
+test('getHealth returns the fixture body on success', async () => {
+    await withFixture(
+        () => ({ status: 200, body: { status: 'ok' } }),
+        async (baseUrl) => {
+            const result = await routerClient.getHealth({ baseUrl });
+            assert.deepEqual(result, { status: 'ok' });
+        },
+    );
+});
+
+test('getOrderBook URL-encodes exchange and symbol', async () => {
+    let capturedPath = '';
+    await withFixture(
+        (path) => {
+            capturedPath = path;
+            return { status: 200, body: { exchangeId: 'kraken', symbol: 'BTC/USDT' } };
+        },
+        async (baseUrl) => {
+            await routerClient.getOrderBook('kraken', 'BTC/USDT', { baseUrl });
+        },
+    );
+    assert.equal(capturedPath, '/orderbook/kraken/BTC%2FUSDT');
+});
+
+test('getBestPrice builds the correct query string', async () => {
+    let capturedPath = '';
+    await withFixture(
+        (path) => {
+            capturedPath = path;
+            return { status: 200, body: { best: null } };
+        },
+        async (baseUrl) => {
+            await routerClient.getBestPrice('ETH/USDT', 'sell', 2.5, { baseUrl });
+        },
+    );
+    assert.equal(capturedPath, '/price/best/ETH%2FUSDT?side=sell&amount=2.5');
+});
+
+test('a non-2xx response throws with the error body message', async () => {
+    await withFixture(
+        () => ({ status: 404, body: { error: 'no cached order book for kraken:BTC/USDT' } }),
+        async (baseUrl) => {
+            await assert.rejects(
+                () => routerClient.getOrderBook('kraken', 'BTC/USDT', { baseUrl }),
+                /no cached order book for kraken:BTC\/USDT/,
+            );
+        },
+    );
+});
+
+test('listSymbols and getExchangesStatus round-trip fixture data', async () => {
+    await withFixture(
+        (path) => {
+            if (path === '/symbols') return { status: 200, body: { symbols: ['BTC/USDT'] } };
+            if (path === '/exchanges/status') return { status: 200, body: { exchanges: [] } };
+            return { status: 404, body: { error: 'not found' } };
+        },
+        async (baseUrl) => {
+            assert.deepEqual(await routerClient.listSymbols({ baseUrl }), { symbols: ['BTC/USDT'] });
+            assert.deepEqual(await routerClient.getExchangesStatus({ baseUrl }), { exchanges: [] });
+        },
+    );
+});

--- a/order-router/src/mcp/tools.ts
+++ b/order-router/src/mcp/tools.ts
@@ -5,12 +5,19 @@
 
 export interface RouterClientOptions {
     baseUrl: string;
+    // Forwarded upstream as X-API-Key. The MCP server authenticates its own callers separately;
+    // this is the credential it uses to call the router on their behalf.
+    apiKey?: string;
     fetchImpl?: typeof fetch;
 }
 
 async function getJson (path: string, options: RouterClientOptions): Promise<unknown> {
     const fetchImpl = options.fetchImpl ?? fetch;
-    const response = await fetchImpl(`${options.baseUrl}${path}`);
+    const headers: Record<string, string> = {};
+    if (options.apiKey) {
+        headers['x-api-key'] = options.apiKey;
+    }
+    const response = await fetchImpl(`${options.baseUrl}${path}`, { headers });
     const body = await response.json();
     if (!response.ok) {
         const message = typeof body === 'object' && body && 'error' in body ? String((body as { error: unknown }).error) : response.statusText;

--- a/order-router/src/mcp/tools.ts
+++ b/order-router/src/mcp/tools.ts
@@ -1,0 +1,47 @@
+// Thin proxies over the order-router's own public REST endpoints — the MCP server is just
+// another consumer of the public API, not a second implementation of the routing logic. Kept
+// separate from src/mcp/server.ts (the MCP wiring) so these can be unit tested by pointing
+// `baseUrl` at a local HTTP fixture, without needing a real MCP client/transport.
+
+export interface RouterClientOptions {
+    baseUrl: string;
+    fetchImpl?: typeof fetch;
+}
+
+async function getJson (path: string, options: RouterClientOptions): Promise<unknown> {
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const response = await fetchImpl(`${options.baseUrl}${path}`);
+    const body = await response.json();
+    if (!response.ok) {
+        const message = typeof body === 'object' && body && 'error' in body ? String((body as { error: unknown }).error) : response.statusText;
+        throw new Error(`order-router API ${response.status}: ${message}`);
+    }
+    return body;
+}
+
+export function getHealth (options: RouterClientOptions): Promise<unknown> {
+    return getJson('/health', options);
+}
+
+export function getExchangesStatus (options: RouterClientOptions): Promise<unknown> {
+    return getJson('/exchanges/status', options);
+}
+
+export function listSymbols (options: RouterClientOptions): Promise<unknown> {
+    return getJson('/symbols', options);
+}
+
+export function getOrderBook (exchange: string, symbol: string, options: RouterClientOptions): Promise<unknown> {
+    const path = `/orderbook/${encodeURIComponent(exchange)}/${encodeURIComponent(symbol)}`;
+    return getJson(path, options);
+}
+
+export function getBestPrice (
+    symbol: string,
+    side: 'buy' | 'sell',
+    amount: number,
+    options: RouterClientOptions,
+): Promise<unknown> {
+    const path = `/price/best/${encodeURIComponent(symbol)}?side=${side}&amount=${amount}`;
+    return getJson(path, options);
+}

--- a/order-router/src/metrics.test.ts
+++ b/order-router/src/metrics.test.ts
@@ -1,0 +1,101 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { OrderBookCache } from './cache/orderBookCache.js';
+import { buildMetricsRegistry } from './metrics.js';
+import type { CachedOrderBook } from './types.js';
+
+function book (overrides: Partial<CachedOrderBook> = {}): CachedOrderBook {
+    return {
+        exchangeId: 'kraken',
+        symbol: 'BTC/USDT',
+        bids: [{ price: 100, amount: 5 }],
+        asks: [{ price: 101, amount: 5 }],
+        exchangeTimestamp: Date.now(),
+        receivedAt: Date.now(),
+        sequence: 1,
+        ...overrides,
+    };
+}
+
+function makeRegistry (cache: OrderBookCache, staleBookMs = 5000, wsCount = 0) {
+    return buildMetricsRegistry({ cache, staleBookMs, getWsConnectionCount: () => wsCount });
+}
+
+test('exposes exchange health as metrics derived from the cache', async () => {
+    const cache = new OrderBookCache();
+    cache.initHealth('kraken');
+    cache.recordUpdate('kraken');
+    cache.recordUpdate('kraken');
+    cache.recordReconnect('kraken');
+    const text = await makeRegistry(cache).metrics();
+
+    assert.match(text, /order_router_exchange_connected\{exchange="kraken"\} 1/);
+    assert.match(text, /order_router_exchange_updates_total\{exchange="kraken"\} 2/);
+    assert.match(text, /order_router_exchange_reconnects_total\{exchange="kraken"\} 1/);
+});
+
+test('a disconnected exchange reports connected=0', async () => {
+    const cache = new OrderBookCache();
+    cache.initHealth('kraken');
+    cache.recordUpdate('kraken');
+    cache.recordError('kraken', 'socket closed');
+    const text = await makeRegistry(cache).metrics();
+    assert.match(text, /order_router_exchange_connected\{exchange="kraken"\} 0/);
+});
+
+test('last_update_age rises with staleness rather than reporting zero', async () => {
+    // The key alerting signal: a silently dead subscription keeps connected=1 while data rots.
+    const cache = new OrderBookCache();
+    cache.initHealth('kraken');
+    cache.recordUpdate('kraken');
+    const health = cache.getHealth()[0];
+    health!.lastUpdateAt = Date.now() - 30_000;
+
+    const text = await makeRegistry(cache).metrics();
+    const match = /order_router_exchange_last_update_age_seconds\{exchange="kraken"\} ([\d.]+)/.exec(text);
+    assert.ok(match, 'age metric present');
+    assert.ok(Number(match![1]) >= 29, `age should reflect ~30s staleness, got ${match![1]}`);
+});
+
+test('an exchange that never updated reports uptime, not zero age', async () => {
+    // Otherwise a connector that never produced a single message looks identical to one that
+    // just updated — the exact failure that would go unnoticed.
+    const cache = new OrderBookCache();
+    cache.initHealth('kraken');
+    const text = await makeRegistry(cache).metrics();
+    const match = /order_router_exchange_last_update_age_seconds\{exchange="kraken"\} ([\d.]+)/.exec(text);
+    assert.ok(match);
+    assert.ok(Number(match![1]) > 0, 'never-updated exchange must not report age 0');
+});
+
+test('counts cached books, symbols and stale books', async () => {
+    const cache = new OrderBookCache();
+    cache.setBook(book());
+    cache.setBook(book({ exchangeId: 'coinbase' }));
+    cache.setBook(book({ symbol: 'ETH/USDT', receivedAt: Date.now() - 60_000 }));
+
+    const text = await makeRegistry(cache, 5000).metrics();
+    assert.match(text, /order_router_cached_books 3/);
+    assert.match(text, /order_router_cached_symbols 2/);
+    assert.match(text, /order_router_stale_books 1/);
+});
+
+test('stale book counting respects the configured threshold', async () => {
+    const cache = new OrderBookCache();
+    cache.setBook(book({ receivedAt: Date.now() - 10_000 }));
+    assert.equal(cache.countStaleBooks(5_000), 1, 'older than threshold => stale');
+    assert.equal(cache.countStaleBooks(60_000), 0, 'within threshold => fresh');
+});
+
+test('reports open websocket stream connections', async () => {
+    const cache = new OrderBookCache();
+    const text = await makeRegistry(cache, 5000, 7).metrics();
+    assert.match(text, /order_router_ws_stream_connections 7/);
+});
+
+test('includes default process metrics for event loop lag and heap', async () => {
+    // Event loop lag is the first thing to degrade when WS volume outruns the single thread.
+    const text = await makeRegistry(new OrderBookCache()).metrics();
+    assert.match(text, /order_router_nodejs_eventloop_lag_seconds/);
+    assert.match(text, /order_router_nodejs_heap_size_used_bytes/);
+});

--- a/order-router/src/metrics.ts
+++ b/order-router/src/metrics.ts
@@ -1,0 +1,139 @@
+import { Registry, Gauge, Histogram, collectDefaultMetrics } from 'prom-client';
+import type { OrderBookCache } from './cache/orderBookCache.js';
+
+// Metrics are DERIVED FROM CACHE STATE AT SCRAPE TIME rather than incremented alongside it.
+// The cache already owns the authoritative counters (updateCount, reconnectCount, lastUpdateAt);
+// mirroring them into separate Prometheus counters would mean two sources of truth that can drift,
+// and a missed increment is invisible. Reading through a collect() callback makes disagreement
+// with /exchanges/status structurally impossible.
+//
+// Consequence: cumulative series are Gauges whose values happen to be monotonic, not Counters.
+// That is fine for Prometheus (rate()/increase() work on the value, and a process restart resets
+// to 0 exactly as a Counter would) and is the better trade here.
+
+export interface MetricsDeps {
+    cache: OrderBookCache;
+    staleBookMs: number;
+    // Live count of open /stream/best sockets. Injected as a getter because the server owns the
+    // connection map and metrics must not hold a reference that could keep sockets alive.
+    getWsConnectionCount: () => number;
+}
+
+export function buildMetricsRegistry (deps: MetricsDeps): Registry {
+    const registry = new Registry();
+
+    // Node/process internals: heap, GC pauses, and — most relevant for this service — event loop
+    // lag, which is the first thing to degrade when WS message volume outruns a single thread.
+    collectDefaultMetrics({ register: registry, prefix: 'order_router_' });
+
+    new Gauge({
+        name: 'order_router_exchange_connected',
+        help: 'One if the exchange connector has a live subscription, zero otherwise.',
+        labelNames: ['exchange'],
+        registers: [registry],
+        collect () {
+            for (const h of deps.cache.getHealth()) {
+                this.set({ exchange: h.exchangeId }, h.connected ? 1 : 0);
+            }
+        },
+    });
+
+    new Gauge({
+        name: 'order_router_exchange_updates_total',
+        help: 'Cumulative order book updates received per exchange since process start.',
+        labelNames: ['exchange'],
+        registers: [registry],
+        collect () {
+            for (const h of deps.cache.getHealth()) {
+                this.set({ exchange: h.exchangeId }, h.updateCount);
+            }
+        },
+    });
+
+    new Gauge({
+        name: 'order_router_exchange_reconnects_total',
+        help: 'Cumulative reconnects per exchange since process start.',
+        labelNames: ['exchange'],
+        registers: [registry],
+        collect () {
+            for (const h of deps.cache.getHealth()) {
+                this.set({ exchange: h.exchangeId }, h.reconnectCount);
+            }
+        },
+    });
+
+    // The single most important alerting signal. An exchange can hold an open socket while its
+    // subscription is silently dead — `connected` stays 1 and nothing errors, but quotes go stale
+    // and the router keeps ranking on data that no longer reflects the market. Age since last
+    // update catches that; connection state alone does not.
+    new Gauge({
+        name: 'order_router_exchange_last_update_age_seconds',
+        help: 'Seconds since the last book update per exchange. Rises without bound if a subscription dies silently.',
+        labelNames: ['exchange'],
+        registers: [registry],
+        collect () {
+            const now = Date.now();
+            for (const h of deps.cache.getHealth()) {
+                // Never updated yet: report the process uptime instead of 0, so a connector that
+                // never produced a single message is loud rather than indistinguishable from
+                // one that just updated.
+                const ageMs = h.lastUpdateAt === undefined ? process.uptime() * 1000 : now - h.lastUpdateAt;
+                this.set({ exchange: h.exchangeId }, ageMs / 1000);
+            }
+        },
+    });
+
+    new Gauge({
+        name: 'order_router_cached_books',
+        help: 'Number of (exchange, symbol) order books currently cached.',
+        registers: [registry],
+        collect () {
+            this.set(deps.cache.getBookCount());
+        },
+    });
+
+    new Gauge({
+        name: 'order_router_cached_symbols',
+        help: 'Number of distinct symbols currently cached.',
+        registers: [registry],
+        collect () {
+            this.set(deps.cache.listSymbols().length);
+        },
+    });
+
+    // Books excluded from ranking for being older than staleBookMs. Distinct from the age gauge:
+    // this counts how much of the cache is currently unusable for routing, which is what actually
+    // degrades answer quality.
+    new Gauge({
+        name: 'order_router_stale_books',
+        help: 'Cached books older than the staleness threshold, and therefore excluded from ranking.',
+        registers: [registry],
+        collect () {
+            this.set(deps.cache.countStaleBooks(deps.staleBookMs));
+        },
+    });
+
+    new Gauge({
+        name: 'order_router_ws_stream_connections',
+        help: 'Currently open /stream/best WebSocket connections.',
+        registers: [registry],
+        collect () {
+            this.set(deps.getWsConnectionCount());
+        },
+    });
+
+    return registry;
+}
+
+// Separate from the registry builder so the server can record into it from an onResponse hook.
+export function buildHttpHistogram (registry: Registry): Histogram<'method' | 'route' | 'status_code'> {
+    return new Histogram({
+        name: 'order_router_http_request_duration_seconds',
+        help: 'HTTP request duration. The _count series doubles as the request counter.',
+        labelNames: ['method', 'route', 'status_code'],
+        // Tuned to this service: reads are in-memory map lookups, so the interesting resolution is
+        // sub-10ms. Measured p50-p99 across endpoints was 3-18ms under load.
+        buckets: [0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5],
+        registers: [registry],
+    });
+}

--- a/order-router/src/routing/bestPrice.test.ts
+++ b/order-router/src/routing/bestPrice.test.ts
@@ -1,0 +1,102 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { OrderBookCache } from '../cache/orderBookCache.js';
+import { FeeRegistry } from '../cache/feeRegistry.js';
+import { computeBestPrice } from './bestPrice.js';
+import type { CachedOrderBook } from '../types.js';
+
+function book (overrides: Partial<CachedOrderBook>): CachedOrderBook {
+    return {
+        exchangeId: 'test-exchange',
+        symbol: 'BTC/USDT',
+        bids: [{ price: 100, amount: 10 }],
+        asks: [{ price: 101, amount: 10 }],
+        exchangeTimestamp: Date.now(),
+        receivedAt: Date.now(),
+        sequence: 1,
+        ...overrides,
+    };
+}
+
+test('picks the exchange with the best fee-adjusted price, not just the best raw price', () => {
+    const cache = new OrderBookCache();
+    const fees = new FeeRegistry();
+
+    // exchangeA has the better raw ask (100) but a much higher fee than exchangeB's (100.5).
+    cache.setBook(book({ exchangeId: 'exchangeA', asks: [{ price: 100, amount: 5 }] }));
+    cache.setBook(book({ exchangeId: 'exchangeB', asks: [{ price: 100.5, amount: 5 }] }));
+    fees.setFee('exchangeA', 'BTC/USDT', 0.01);
+    fees.setFee('exchangeB', 'BTC/USDT', 0.0005);
+
+    const result = computeBestPrice(cache, fees, 'BTC/USDT', 'buy', 1, 5000);
+
+    // A: 100 * 1.01 = 101; B: 100.5 * 1.0005 = 100.55025 -> B wins despite the worse raw price.
+    assert.equal(result.best?.exchangeId, 'exchangeB');
+});
+
+test('walks the book across levels to compute a volume-weighted average price', () => {
+    const cache = new OrderBookCache();
+    const fees = new FeeRegistry();
+    fees.setFee('test-exchange', 'BTC/USDT', 0);
+
+    cache.setBook(book({
+        asks: [
+            { price: 100, amount: 1 },
+            { price: 101, amount: 1 },
+            { price: 102, amount: 10 },
+        ],
+    }));
+
+    const result = computeBestPrice(cache, fees, 'BTC/USDT', 'buy', 2, 5000);
+
+    // Fills 1 @ 100 + 1 @ 101 = 201 notional / 2 = 100.5 average.
+    assert.equal(result.best?.averagePrice, 100.5);
+    assert.equal(result.best?.filledAmount, 2);
+    assert.equal(result.best?.fullyFillable, true);
+});
+
+test('marks a quote not fully fillable when the book lacks enough depth', () => {
+    const cache = new OrderBookCache();
+    const fees = new FeeRegistry();
+    cache.setBook(book({ asks: [{ price: 100, amount: 1 }] }));
+
+    const result = computeBestPrice(cache, fees, 'BTC/USDT', 'buy', 5, 5000);
+
+    assert.equal(result.best?.fullyFillable, false);
+    assert.equal(result.best?.filledAmount, 1);
+});
+
+test('sell side walks the bid side, not the ask side', () => {
+    const cache = new OrderBookCache();
+    const fees = new FeeRegistry();
+    fees.setFee('test-exchange', 'BTC/USDT', 0);
+    cache.setBook(book({
+        bids: [{ price: 99, amount: 3 }],
+        asks: [{ price: 500, amount: 3 }], // deliberately implausible, must not be used for a sell
+    }));
+
+    const result = computeBestPrice(cache, fees, 'BTC/USDT', 'sell', 2, 5000);
+
+    assert.equal(result.best?.averagePrice, 99);
+});
+
+test('excludes stale books from ranking', () => {
+    const cache = new OrderBookCache();
+    const fees = new FeeRegistry();
+    cache.setBook(book({ receivedAt: Date.now() - 60_000 })); // 60s old
+
+    const result = computeBestPrice(cache, fees, 'BTC/USDT', 'buy', 1, 5000); // 5s staleness cutoff
+
+    assert.equal(result.best, undefined);
+    assert.equal(result.quotes.length, 1); // still reported, just not eligible as "best"
+});
+
+test('returns no best quote when no books exist for the symbol', () => {
+    const cache = new OrderBookCache();
+    const fees = new FeeRegistry();
+
+    const result = computeBestPrice(cache, fees, 'NONEXISTENT/USDT', 'buy', 1, 5000);
+
+    assert.equal(result.best, undefined);
+    assert.deepEqual(result.quotes, []);
+});

--- a/order-router/src/routing/bestPrice.ts
+++ b/order-router/src/routing/bestPrice.ts
@@ -1,0 +1,80 @@
+import type { OrderBookCache } from '../cache/orderBookCache.js';
+import type { ExchangeConnector } from '../connectors/exchangeConnector.js';
+import type { BookLevel, RoutingQuote, RoutingResult } from '../types.js';
+
+// Walks book levels to fill `amount`, returns the volume-weighted average
+// price actually achievable and whether the book had enough depth to fill it.
+function walkBook (levels: BookLevel[], amount: number): { averagePrice: number | undefined; filledAmount: number } {
+    let remaining = amount;
+    let notional = 0;
+    let filled = 0;
+    for (const level of levels) {
+        if (remaining <= 0) break;
+        const take = Math.min(remaining, level.amount);
+        notional += take * level.price;
+        filled += take;
+        remaining -= take;
+    }
+    if (filled === 0) {
+        return { averagePrice: undefined, filledAmount: 0 };
+    }
+    return { averagePrice: notional / filled, filledAmount: filled };
+}
+
+export function computeBestPrice (
+    cache: OrderBookCache,
+    connectors: Map<string, ExchangeConnector>,
+    symbol: string,
+    side: 'buy' | 'sell',
+    amount: number,
+    staleBookMs: number,
+): RoutingResult {
+    const books = cache.getBooksForSymbol(symbol);
+    const now = Date.now();
+    const quotes: RoutingQuote[] = [];
+
+    for (const book of books) {
+        const bookAgeMs = now - book.receivedAt;
+        // A buy order gets filled by walking the ask side (you're paying the ask), and vice versa.
+        const levels = side === 'buy' ? book.asks : book.bids;
+        const { averagePrice, filledAmount } = walkBook(levels, amount);
+        const connector = connectors.get(book.exchangeId);
+        const takerFeeRate = connector?.getTakerFee(symbol) ?? 0.001;
+        const effectivePriceWithFee = averagePrice === undefined
+            ? undefined
+            : side === 'buy'
+                ? averagePrice * (1 + takerFeeRate)
+                : averagePrice * (1 - takerFeeRate);
+
+        quotes.push({
+            exchangeId: book.exchangeId,
+            side,
+            requestedAmount: amount,
+            filledAmount,
+            averagePrice,
+            effectivePriceWithFee,
+            takerFeeRate,
+            fullyFillable: filledAmount >= amount,
+            bookAgeMs,
+        });
+    }
+
+    // Prefer fully-fillable, fresh quotes; rank by effective price (lowest for buy, highest for sell).
+    const usable = quotes.filter((q) => q.effectivePriceWithFee !== undefined && q.bookAgeMs <= staleBookMs);
+    const ranked = usable.sort((a, b) => {
+        if (a.fullyFillable !== b.fullyFillable) {
+            return a.fullyFillable ? -1 : 1;
+        }
+        const aPrice = a.effectivePriceWithFee as number;
+        const bPrice = b.effectivePriceWithFee as number;
+        return side === 'buy' ? aPrice - bPrice : bPrice - aPrice;
+    });
+
+    return {
+        symbol,
+        side,
+        amount,
+        best: ranked[0],
+        quotes,
+    };
+}

--- a/order-router/src/routing/bestPrice.ts
+++ b/order-router/src/routing/bestPrice.ts
@@ -1,5 +1,5 @@
 import type { OrderBookCache } from '../cache/orderBookCache.js';
-import type { ExchangeConnector } from '../connectors/exchangeConnector.js';
+import type { FeeRegistry } from '../cache/feeRegistry.js';
 import type { BookLevel, RoutingQuote, RoutingResult } from '../types.js';
 
 // Walks book levels to fill `amount`, returns the volume-weighted average
@@ -23,7 +23,7 @@ function walkBook (levels: BookLevel[], amount: number): { averagePrice: number 
 
 export function computeBestPrice (
     cache: OrderBookCache,
-    connectors: Map<string, ExchangeConnector>,
+    feeRegistry: FeeRegistry,
     symbol: string,
     side: 'buy' | 'sell',
     amount: number,
@@ -38,8 +38,7 @@ export function computeBestPrice (
         // A buy order gets filled by walking the ask side (you're paying the ask), and vice versa.
         const levels = side === 'buy' ? book.asks : book.bids;
         const { averagePrice, filledAmount } = walkBook(levels, amount);
-        const connector = connectors.get(book.exchangeId);
-        const takerFeeRate = connector?.getTakerFee(symbol) ?? 0.001;
+        const takerFeeRate = feeRegistry.getFee(book.exchangeId, symbol);
         const effectivePriceWithFee = averagePrice === undefined
             ? undefined
             : side === 'buy'

--- a/order-router/src/sharding/messages.ts
+++ b/order-router/src/sharding/messages.ts
@@ -1,0 +1,34 @@
+import type { CachedOrderBook, ExchangeHealth } from '../types.js';
+
+export interface ShardAssignment {
+    exchangeId: string;
+    symbols: string[];
+}
+
+// Parent -> shard worker: which exchanges/symbols this shard owns.
+export interface ShardInitMessage {
+    type: 'init';
+    assignments: ShardAssignment[];
+}
+
+// Shard worker -> parent: forwarded on every book update, health change, and taker-fee discovery.
+// These are the only messages that cross the process boundary — the API layer's read path never
+// does; only the (already-async, off-the-request-path) cache-write path pays the IPC cost.
+export interface ShardBookMessage {
+    type: 'book';
+    book: CachedOrderBook;
+}
+
+export interface ShardHealthMessage {
+    type: 'health';
+    health: ExchangeHealth;
+}
+
+export interface ShardFeeMessage {
+    type: 'fee';
+    exchangeId: string;
+    symbol: string;
+    takerFeeRate: number;
+}
+
+export type ShardToParentMessage = ShardBookMessage | ShardHealthMessage | ShardFeeMessage;

--- a/order-router/src/sharding/orchestrator.test.ts
+++ b/order-router/src/sharding/orchestrator.test.ts
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { partitionAssignments } from './orchestrator.js';
+import type { ShardAssignment } from './messages.js';
+
+function assignment (exchangeId: string, symbolCount: number): ShardAssignment {
+    return { exchangeId, symbols: Array.from({ length: symbolCount }, (_, i) => `SYM${i}/USDT`) };
+}
+
+test('every assignment appears in exactly one group, none dropped or duplicated', () => {
+    const assignments = [assignment('a', 100), assignment('b', 50), assignment('c', 10), assignment('d', 200)];
+    const groups = partitionAssignments(assignments, 2);
+
+    const allExchangeIds = groups.flat().map((a) => a.exchangeId).sort();
+    assert.deepEqual(allExchangeIds, ['a', 'b', 'c', 'd']);
+});
+
+test('returns exactly shardCount groups, even if some end up empty', () => {
+    const assignments = [assignment('a', 10)];
+    const groups = partitionAssignments(assignments, 3);
+    assert.equal(groups.length, 3);
+});
+
+test('greedily balances total symbol count across shards', () => {
+    // 100 + 50 + 10 should not all land on one shard when there are 2 shards available;
+    // the largest (100) and next-largest pair should end up balanced rather than lopsided.
+    const assignments = [assignment('big', 100), assignment('medium', 50), assignment('small', 10)];
+    const groups = partitionAssignments(assignments, 2);
+
+    const totals = groups.map((g) => g.reduce((sum, a) => sum + a.symbols.length, 0));
+    // Greedy load balance: big(100) -> shard0, medium(50) -> shard1, small(10) -> shard1 (60) since
+    // shard1 (0) < shard0 (100) at that point, then small goes to whichever is smaller.
+    assert.equal(totals.reduce((a, b) => a + b, 0), 160);
+    // The imbalance should be much smaller than dumping everything on one shard (160 vs 0).
+    assert.ok(Math.max(...totals) - Math.min(...totals) <= 100);
+});
+
+test('single shard puts everything in one group', () => {
+    const assignments = [assignment('a', 10), assignment('b', 20)];
+    const groups = partitionAssignments(assignments, 1);
+    assert.equal(groups.length, 1);
+    assert.equal(groups[0]?.length, 2);
+});

--- a/order-router/src/sharding/orchestrator.ts
+++ b/order-router/src/sharding/orchestrator.ts
@@ -1,0 +1,74 @@
+import { fork, type ChildProcess } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import type { Logger } from 'pino';
+import type { OrderBookCache } from '../cache/orderBookCache.js';
+import type { FeeRegistry } from '../cache/feeRegistry.js';
+import type { ShardAssignment, ShardToParentMessage } from './messages.js';
+
+const SHARD_WORKER_PATH = fileURLToPath(new URL('./shardWorker.js', import.meta.url));
+
+// Greedy load-balance by symbol count (a rough proxy for message-rate load, since we don't have
+// per-symbol throughput data at startup) — sort exchanges by symbol count descending, always hand
+// the next one to whichever shard currently has the smallest total. Not optimal, but avoids the
+// worst case of round-robin dumping every high-symbol-count exchange on the same shard index.
+export function partitionAssignments (assignments: ShardAssignment[], shardCount: number): ShardAssignment[][] {
+    const groups: ShardAssignment[][] = Array.from({ length: shardCount }, () => []);
+    const groupLoad = new Array(shardCount).fill(0);
+    const sorted = [...assignments].sort((a, b) => b.symbols.length - a.symbols.length);
+    for (const assignment of sorted) {
+        let minIdx = 0;
+        for (let i = 1; i < shardCount; i++) {
+            if (groupLoad[i]! < groupLoad[minIdx]!) minIdx = i;
+        }
+        groups[minIdx]!.push(assignment);
+        groupLoad[minIdx]! += assignment.symbols.length;
+    }
+    return groups;
+}
+
+// Forks one child process per shard group, each running its own set of ExchangeConnectors, and
+// relays their book/health/fee messages into the parent's cache/feeRegistry. The parent's API
+// server reads from that same cache — still a synchronous in-process Map read on every request;
+// only the write path (a shard's connector -> parent cache) crosses a process boundary, and only
+// asynchronously.
+export function startShards (
+    groups: ShardAssignment[][],
+    cache: OrderBookCache,
+    feeRegistry: FeeRegistry,
+    logger: Logger,
+): ChildProcess[] {
+    const children: ChildProcess[] = [];
+    groups.forEach((assignments, shardIndex) => {
+        if (assignments.length === 0) return;
+        const child = fork(SHARD_WORKER_PATH);
+        children.push(child);
+        const shardLogger = logger.child({ shard: shardIndex, pid: child.pid });
+
+        child.on('message', (message: ShardToParentMessage) => {
+            switch (message.type) {
+                case 'book':
+                    cache.setBook(message.book);
+                    break;
+                case 'health':
+                    cache.setHealth(message.health);
+                    break;
+                case 'fee':
+                    feeRegistry.setFee(message.exchangeId, message.symbol, message.takerFeeRate);
+                    break;
+            }
+        });
+        child.on('exit', (code) => {
+            shardLogger.error({ code }, 'shard process exited unexpectedly');
+        });
+        child.on('error', (err) => {
+            shardLogger.error({ err }, 'shard process error');
+        });
+
+        child.send({ type: 'init', assignments });
+        shardLogger.info(
+            { exchanges: assignments.map((a) => a.exchangeId), exchangeCount: assignments.length },
+            'shard started',
+        );
+    });
+    return children;
+}

--- a/order-router/src/sharding/shardWorker.ts
+++ b/order-router/src/sharding/shardWorker.ts
@@ -1,0 +1,65 @@
+import { config } from '../config.js';
+import { logger } from '../logger.js';
+import { OrderBookCache } from '../cache/orderBookCache.js';
+import { FeeRegistry } from '../cache/feeRegistry.js';
+import { ExchangeConnector } from '../connectors/exchangeConnector.js';
+import type { ShardInitMessage, ShardToParentMessage } from './messages.js';
+
+const HEALTH_FLUSH_MS = 2000;
+
+function send (message: ShardToParentMessage): void {
+    process.send?.(message);
+}
+
+async function runShard (assignments: ShardInitMessage['assignments']): Promise<void> {
+    const shardLogger = logger.child({ shard: process.pid });
+    const cache = new OrderBookCache();
+    const feeRegistry = new FeeRegistry();
+
+    // Relay every book write and every fee discovery to the parent immediately — this is the
+    // cache's async write path, off the API's synchronous request path, so the IPC hop here
+    // doesn't cost the router a request-time round trip the way a Redis read would.
+    cache.on('book', (book) => send({ type: 'book', book }));
+    cache.on('health', (health) => send({ type: 'health', health }));
+    feeRegistry.on('fee', (msg) => send({ type: 'fee', ...msg }));
+
+    // Health counters (updateCount, lastUpdateAt) change on every message too, but flushing those
+    // on the same per-message cadence would double IPC traffic for information that's only ever
+    // read from a monitoring endpoint — a slow timer is enough for that.
+    setInterval(() => {
+        for (const health of cache.getHealth()) {
+            send({ type: 'health', health });
+        }
+    }, HEALTH_FLUSH_MS);
+
+    const connectors = assignments.map(
+        ({ exchangeId }) => new ExchangeConnector(
+            exchangeId,
+            cache,
+            feeRegistry,
+            shardLogger,
+            undefined,
+            config.maxSymbolsPerSubscription,
+            config.maxSymbolsPerExchangeOverrides.get(exchangeId),
+        ),
+    );
+
+    await Promise.all(
+        assignments.map(async ({ exchangeId, symbols }, i) => {
+            try {
+                await connectors[i]!.start(symbols);
+                shardLogger.info({ exchange: exchangeId, symbolCount: symbols.length }, 'shard connector started');
+            } catch (err) {
+                shardLogger.error({ exchange: exchangeId, err }, 'shard connector failed to start');
+            }
+        }),
+    );
+
+    process.on('disconnect', () => process.exit(0));
+}
+
+process.on('message', (message: ShardInitMessage) => {
+    if (message.type === 'init') {
+        void runShard(message.assignments);
+    }
+});

--- a/order-router/src/types.ts
+++ b/order-router/src/types.ts
@@ -1,0 +1,43 @@
+export interface BookLevel {
+    price: number;
+    amount: number;
+}
+
+export interface CachedOrderBook {
+    exchangeId: string;
+    symbol: string;
+    bids: BookLevel[];
+    asks: BookLevel[];
+    exchangeTimestamp: number | undefined;
+    receivedAt: number;
+    sequence: number;
+}
+
+export interface ExchangeHealth {
+    exchangeId: string;
+    connected: boolean;
+    lastUpdateAt: number | undefined;
+    updateCount: number;
+    reconnectCount: number;
+    lastError: string | undefined;
+}
+
+export interface RoutingQuote {
+    exchangeId: string;
+    side: 'buy' | 'sell';
+    requestedAmount: number;
+    filledAmount: number;
+    averagePrice: number | undefined;
+    effectivePriceWithFee: number | undefined;
+    takerFeeRate: number;
+    fullyFillable: boolean;
+    bookAgeMs: number;
+}
+
+export interface RoutingResult {
+    symbol: string;
+    side: 'buy' | 'sell';
+    amount: number;
+    best: RoutingQuote | undefined;
+    quotes: RoutingQuote[];
+}

--- a/order-router/tsconfig.json
+++ b/order-router/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Scaffolds `order-router/`, a standalone Node/TypeScript service (depends on `ccxt` as a library — no changes to `ts/src/**` or the build/transpile pipeline) that aggregates live L2 order books across exchanges via `ccxt.pro` WebSocket connections and serves best-execution price lookups that account for order size (book-walking, not just top-of-book) and taker fees.

- Per-exchange `ExchangeConnector` (isolated failure domain, exponential-backoff reconnect) caches full L2 books in an in-process `OrderBookCache` — reads never touch the network, no Redis/network hop in the hot path.
- `/price/best/:symbol?side=&amount=` walks the cached book to the requested size and ranks exchanges by fee-adjusted effective price, not raw top-of-book.
- `/stream/best/:symbol` pushes on book-change (event-driven, coalesced via `setImmediate`) rather than polling.
- Fastify API: `/health`, `/exchanges/status`, `/symbols`, `/orderbook/:exchange/:symbol`, `/price/best/:symbol`, `/stream/best/:symbol` (WS).
- Dockerfile + docker-compose for single-host deployment.
- `benchmark/ws-latency.mjs` — WS latency/depth benchmark script, with results and important caveats documented in `order-router/README.md` (Binance/Bybit/OKX unreachable from this dev sandbox due to geo-blocking; latency figures affected by unsynced container clock — needs re-running from real deployment infra).

`README.md` also documents the architecture decisions made along the way and why: single-process Node vs. a split TS-collector/Redis/Rust-API design (rejected — Redis round-trip cost dominates any language-layer speed gain), and the WS connection-count-vs-message-throughput scaling analysis.

## Test plan

- [x] `npx tsc -p order-router/tsconfig.json` — clean build
- [x] Ran the service live against reachable exchanges (Kraken, Coinbase, KuCoin, Bitget, Gate — Binance/Bybit/OKX geo-blocked from dev sandbox) and verified `/health`, `/symbols`, `/exchanges/status`, `/orderbook/:exchange/:symbol`, `/price/best/:symbol` (both buy and sell, various sizes) all return correct, sane data
- [x] Verified fee-adjusted ranking picks the actual best effective price across exchanges, not just best top-of-book
- [x] Verified `/stream/best/:symbol` pushes on book change via a WS test client
- [ ] Re-benchmark from production-target infra with unrestricted exchange egress and NTP-synced clock (see README "Known gaps")
- [ ] Load-test aggregate WS message throughput at production exchange/symbol scale

## Notes

This is diff-scoped to `order-router/` only — no `ts/src/**`, generated files, or other CCXT library code touched. Order *execution* routing (placing real orders) is intentionally out of scope for this milestone; see README "Known gaps" for what's next.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZBbcVGn34SCwcfCkWL218)_